### PR TITLE
Switches to using User Data Directory to store credentials instead of homedir

### DIFF
--- a/packages/cli/src/lib/auth/AuthTokenStore.ts
+++ b/packages/cli/src/lib/auth/AuthTokenStore.ts
@@ -43,8 +43,29 @@ export class AuthTokenStore implements Disposable {
     return path.join(this.#dotDevvitDir, 'token');
   }
 
+  static getUserDataDir(): string | null {
+    const platform = os.platform();
+    const homeDir = os.homedir();
+
+    switch (platform) {
+      case 'win32':
+          return process.env.LOCALAPPDATA || path.join(homeDir, 'AppData', 'Local');
+      case 'darwin':
+          return path.join(homeDir, 'Library', 'Application Support');
+      case 'linux':
+          return process.env.XDG_DATA_HOME || path.join(homeDir, '.local', 'share');
+      default:
+          return null;
+    }
+  }
+
   constructor(dotDevvitDir: string = path.join(os.homedir(), '.devvit')) {
-    this.#dotDevvitDir = dotDevvitDir;
+    let userDataDir = AuthTokenStore.getUserDataDir();
+    if (userDataDir) {
+      this.#dotDevvitDir = path.join(userDataDir, "devvit");
+    } else {
+      this.#dotDevvitDir = dotDevvitDir;
+    }
   }
 
   async readFSToken(): Promise<TokenInfo | undefined> {


### PR DESCRIPTION
## 💸 TL;DR
- Switches to using User Data Directory to store credentials instead of homedir.
- If User Data Directory is not applicable for an OS then it falls back on using the homedir to save credentials.

## 📜 Details
The goal of this PR is to make devvit conform to each operating system's user data directory guidelines for storing app data instead of creating directory in home directory. This is where the devvit directory will be depending on the OS.

- **Windows**: `C:\\Users\\<user>\\AppData\\Local\\devvit`
- **Mac OS**: `/Users/<user>/Library/Application Support/devvit`
- **Linux**: `/home/<user>/.local/share/devvit`

If none of the OS in the list above matches then it defaults to using homedir for storing credentials. 

## 🧪 Testing Steps / Validation
This PR hasn't been tested yet because I couldn't build locally on my machine :/

## ✅ Checks
- [ ] CI tests (if present) are passing
- [ ] Adheres to code style for repo
- [✅ ] Contributor License Agreement (CLA) completed if not a Reddit employee
