### PR TITLE
[docs] Update links in the payments doc to be relative instead of absolute

### DIFF
--- a/devvit-docs/docs/capabilities/payments.md
+++ b/devvit-docs/docs/capabilities/payments.md
@@ -54,12 +54,12 @@ Products are registered via a `src/products.json` file in your local app. The JS
 Each product in the `products` field comprises of the following attributes:
 
 | **Attribute** | **Description**                                                                                                                                                                                                                                        |
-| ------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| ------------- |--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | `sku`         | A product identifier that can be used to group orders or organize your products. Each sku must be unique for each product in your app.                                                                                                                 |
 | `displayName` | The official name of the product that is displayed in purchase confirmation screens. The name must be fewer than 50 characters, including spaces.                                                                                                      |
 | `description` | A text string that describes the product and is displayed in purchase confirmation screens. The description must be fewer than 150 characters, including spaces.                                                                                       |
 | `price`       | An predefined integer that sets the product price in Reddit gold. See details below.                                                                                                                                                                   |
-| `image.icon`  | **(optional)** The path to the icon that represents your product in your [assets](https://developers.reddit.com/docs/app_image_assets) folder.                                                                                                         |
+| `image.icon`  | **(optional)** The path to the icon that represents your product in your [assets](../app_image_assets) folder.                                                                                                                                         |
 | `metadata`    | **(optional)** An optional object that contains additional attributes you want to use to group and filter products. Keys and values must be alphanumeric (a - Z, 0 - 9, and - ) and contain 30 characters or less. You can add up to 10 metadata keys. |
 
 :::note
@@ -67,7 +67,7 @@ Actual payments will not be processed until your products are approved. While yo
 :::
 
 :::note
-Registered products are updated every time an app is uploaded, including when you use [Devvit playtest](https://developers.reddit.com/docs/playtest).
+Registered products are updated every time an app is uploaded, including when you use [Devvit playtest](../playtest).
 :::
 
 ### Pricing


### PR DESCRIPTION
Super minor, but using relative links instead of absolute makes the docs work properly when using `yarn docusaurus serve`. 