### PR TITLE
Update the URI for sportradar's API 

### DIFF
--- a/packages/apps/live-scores/src/sports/sportradar/BasketballSchedule.ts
+++ b/packages/apps/live-scores/src/sports/sportradar/BasketballSchedule.ts
@@ -26,7 +26,7 @@ export async function fetchNbaSchedule(
   let data;
   const apiKey = await context.settings.get(APIKey.nba);
   try {
-    const url = `https://api.sportradar.us/nba/production/v8/en/games/2023/${seasonType}/schedule.json?api_key=${apiKey}`;
+    const url = `https://api.sportradar.us/nba/production/v8/en/games/2024/${seasonType}/schedule.json?api_key=${apiKey}`;
     // console.log(request.url);
     const response = await fetch(url);
     if (!response.ok) throw Error(`HTTP error ${response.status}: ${response.statusText}`);
@@ -63,7 +63,7 @@ export async function fetchNcaaMensBasketballSchedule(
   let data;
   const apiKey = await context.settings.get(APIKey.ncaamb);
   try {
-    const url = `https://api.sportradar.us/ncaamb/production/v8/en/games/2023/${seasonType}/schedule.json?api_key=${apiKey}`;
+    const url = `https://api.sportradar.us/ncaamb/production/v8/en/games/2024/${seasonType}/schedule.json?api_key=${apiKey}`;
     // console.log(url)
     const response = await fetch(url);
     if (!response.ok) throw Error(`HTTP error ${response.status}: ${response.statusText}`);

--- a/packages/apps/live-scores/src/sports/sportradar/NFLSchedule.ts
+++ b/packages/apps/live-scores/src/sports/sportradar/NFLSchedule.ts
@@ -70,7 +70,7 @@ export async function fetchNflSchedule(
   const apiKey = await context.settings.get(APIKey.nfl);
   try {
     const request = new Request(
-      `https://api.sportradar.us/nfl/official/production/v7/en/games/2023/${seasonType}/schedule.json?api_key=${apiKey}`
+      `https://api.sportradar.us/nfl/official/production/v7/en/games/2024/${seasonType}/schedule.json?api_key=${apiKey}`
     );
     // console.log(request.url);
     const response = await fetch(request);


### PR DESCRIPTION
TL;DR
- The `scoreboard` devvit app fetches its list of possible games from the Sportradar schedule API.
- The request hardcodes the year `2023` as part of the path (eg `api.sportradar.us/..../games/2023/${seasonType}/schedule.json`). This results in scoreboard app unable support the 2024 NFL season (beginning Thursday Sept 5th) as well as 2024 NBA and NCAA seasons (Oct 22 and Nov 4 respectively)
- The proposed change updates the request to hardcode the year `2024` as part of the path.
