### PR TITLE
Pass ban context through when banning users

### DIFF
--- a/packages/public-api/src/apis/reddit/RedditAPIClient.ts
+++ b/packages/public-api/src/apis/reddit/RedditAPIClient.ts
@@ -734,6 +734,7 @@ export class RedditAPIClient {
         banMessage: options.message,
         note: options.note,
         duration: options.duration,
+        banContext: options.context,
       },
       this.#metadata
     );

--- a/packages/public-api/src/apis/reddit/models/Subreddit.ts
+++ b/packages/public-api/src/apis/reddit/models/Subreddit.ts
@@ -728,6 +728,7 @@ export class Subreddit {
         banMessage: options.message,
         note: options.note,
         duration: options.duration,
+        banContext: options.context,
       },
       this.#metadata
     );


### PR DESCRIPTION
<!-- If this pull request closes an issue, please mention the issue number below -->
Fixes #99

## 💸 TL;DR
When a user is banned, the `context` property of the BanUserOptions type is not passed up to User.createRelationship. This means that the modmail received by the user does not include full details of why the user has been banned.

## 🧪 Testing Steps / Validation
Example code:

Via reddit API:
```ts
  await context.reddit.banUser({
      subredditName: "fsvsandbox",
      username: "fsvtestalt",
      context: "t3_1esvalw",
      duration: 1,
  });
```

Via method on `Subreddit` class:
```ts
  const subreddit = await context.reddit.getCurrentSubreddit();
  await subreddit.banUser({
      username: "fsvtestalt",
      context: "t3_1esvalw",
      duration: 1,
  });
```

Expected outcome: the modmail sent to the end user should include a link to the post or comment that is referenced by the context attribute.

## ✅ Checks
<!-- Make sure your pr passes the CI checks and do check the following fields as needed - -->
- [x] CI tests (if present) are passing
- [x] Adheres to code style for repo
- [x] Contributor License Agreement (CLA) completed if not a Reddit employee
