### PR TITLE
fix: allow WikiPage.#revisionAuthor to be undefined

### DIFF
--- a/packages/public-api/src/apis/reddit/models/WikiPage.ts
+++ b/packages/public-api/src/apis/reddit/models/WikiPage.ts
@@ -75,7 +75,7 @@ export class WikiPage {
   #revisionId: string;
   #revisionDate: Date;
   #revisionReason: string;
-  #revisionAuthor: User;
+  #revisionAuthor: User | undefined;
 
   #metadata: Metadata | undefined;
 
@@ -97,9 +97,9 @@ export class WikiPage {
     this.#revisionId = data.revisionId;
     this.#revisionDate = new Date(data.revisionDate * 1000); // data.revisionDate is represented in seconds, so multiply by 1000 to get milliseconds
     this.#revisionReason = data.reason ?? '';
-
-    assertNonNull(data.revisionBy?.data, 'Wiki page author details are missing');
-    this.#revisionAuthor = new User(data.revisionBy.data, metadata);
+    this.#revisionAuthor = data.revisionBy?.data
+      ? new User(data.revisionBy.data, metadata)
+      : undefined;
 
     this.#metadata = metadata;
   }
@@ -140,7 +140,7 @@ export class WikiPage {
   }
 
   /** The author of this revision. */
-  get revisionAuthor(): User {
+  get revisionAuthor(): User | undefined {
     return this.#revisionAuthor;
   }
 
@@ -154,7 +154,7 @@ export class WikiPage {
     | 'revisionDate'
     | 'revisionReason'
   > & {
-    revisionAuthor: ReturnType<User['toJSON']>;
+    revisionAuthor: ReturnType<User['toJSON']> | undefined;
   } {
     return {
       name: this.#name,
@@ -164,7 +164,7 @@ export class WikiPage {
       revisionId: this.#revisionId,
       revisionDate: this.#revisionDate,
       revisionReason: this.#revisionReason,
-      revisionAuthor: this.#revisionAuthor.toJSON(),
+      revisionAuthor: this.#revisionAuthor?.toJSON(),
     };
   }
 


### PR DESCRIPTION
<!-- If this pull request closes an issue, please mention the issue number below -->
Possibly fixes #108

## 💸 TL;DR
Allows WikiPage.#revisionAuthor to be undefined, as that is a possibility for some wiki pages.

## 📜 Details
Removes `assertNonNull(data.revisionBy?.data, 'Wiki page author details are missing');` from the WikiPage constructor and sets `#revisionAuthor` to be of type `User | undefined` depending on whether `data.revisionBy` exists. Updates `get revisionAuthor()` and `toJSON()` to reflect the type change.

It's worth noting that `revisionBy` is already marked as potentially undefined in the `WikiPage` interface from `@devvit/protos`. `revisionId` and `revisionDate` are not marked that way, but would also be returned as `null` by the Data API in this same edge case of a wiki page with no revision history.

<!-- Add additional details required for the PR: breaking changes, screenshots, external dependency changes -->

## 🧪 Testing Steps / Validation
Untested, as I am unable to set up the environment to produce a successful build even with no changes. TypeScript language server doesn't show any new errors though. Additionally, there are no existing tests for WikiPage found in `/packages/public-api/src/apis/reddit/tests`.

## ✅ Checks
<!-- Make sure your pr passes the CI checks and do check the following fields as needed - -->
- [❌] CI tests (if present) are passing  
 Unable to test, see above.
- [❌] Adheres to code style for repo
 Prettier doesn't even pass on an unmodified `WikiPage.ts` file.
- [✅] Contributor License Agreement (CLA) completed if not a Reddit employee
