### PR TITLE
include conversationIds in GetConversationsResponse

### DIFF
--- a/packages/public-api/src/apis/reddit/models/ModMail.ts
+++ b/packages/public-api/src/apis/reddit/models/ModMail.ts
@@ -316,6 +316,10 @@ export type GetConversationsResponse = {
    */
   conversations: { [id: string]: ConversationData };
   viewerId?: string;
+  /**
+   * Array of conversation ids, ordered by the sort parameter specified in {@link GetConversationsRequest}.
+   */
+  conversationIds: string[];
 };
 
 /**
@@ -411,6 +415,7 @@ export class ModMailService {
     return {
       conversations,
       viewerId: response.viewerId,
+      conversationIds: response.conversationIds,
     };
   }
 

--- a/packages/public-api/src/apis/reddit/tests/__snapshots__/modmail.api.test.ts.snap
+++ b/packages/public-api/src/apis/reddit/tests/__snapshots__/modmail.api.test.ts.snap
@@ -841,6 +841,9 @@ exports[`ModMail API > getConversation() 1`] = `
 
 exports[`ModMail API > getConversations() > with subreddits defined 1`] = `
 {
+  "conversationIds": [
+    "fake_conversation_id",
+  ],
   "conversations": {
     "fake_conversation_id": {
       "authors": [
@@ -927,6 +930,9 @@ exports[`ModMail API > getConversations() > with subreddits defined 1`] = `
 
 exports[`ModMail API > getConversations() > with subreddits undefined 1`] = `
 {
+  "conversationIds": [
+    "fake_conversation_id",
+  ],
   "conversations": {
     "fake_conversation_id": {
       "authors": [


### PR DESCRIPTION
<!-- If this pull request closes an issue, please mention the issue number below -->
Closes #113

## 💸 TL;DR
Adds the `conversationIds` array to the data returned by `modMail.getConversations()`.

## 📜 Details
As documented in #113, `modMail.getConversations()` accepts a sort order, but returns all conversations in an unsorted object. This makes determining the last conversation quite difficult. The API provides the proper order of the conversations with the `conversationIds` array. That array was already present in the protos modmail client, so this PR simply passes along the array from protos response in the public-api modmail client response. 

<!-- Add additional details required for the PR: breaking changes, screenshots, external dependency changes -->

## 🧪 Testing Steps / Validation
Compiled and tested using a Devvit app, sort order provided by protos appears to be correct. Updated the `modmail.api.test.ts.snap` snapshots for the `getConversations` tests to reflect the new response, after that those tests pass.

## ✅ Checks
<!-- Make sure your pr passes the CI checks and do check the following fields as needed - -->
- [✅] CI tests (if present) are passing
  I had to update `modmail.api.test.ts.snap` to reflect the change, after doing so `vitest run` passed.
- [✅] Adheres to code style for repo
  Prettier did not flag any issues with the code I added, although I may not have the proper linting configs.
- [✅] Contributor License Agreement (CLA) completed if not a Reddit employee
