### PR TITLE
Added the ability to nuke all comments of a post in comment-nuke app

### DIFF
--- a/packages/apps/comment-nuke/src/main.ts
+++ b/packages/apps/comment-nuke/src/main.ts
@@ -3,7 +3,7 @@ import { handleNuke, handleNukePost } from './nuke.js';
  
 Devvit.configure({
   redditAPI: true,
-  modLog: true,
+  // modLog: true,
 });
  
 const nukeForm = Devvit.createForm(

--- a/packages/apps/comment-nuke/src/main.ts
+++ b/packages/apps/comment-nuke/src/main.ts
@@ -1,4 +1,4 @@
-import { Devvit } from '@devvit/public-api';
+import { Devvit, FormField } from '@devvit/public-api';
 import { handleNuke, handleNukePost } from './nuke.js';
 
 Devvit.configure({
@@ -6,29 +6,31 @@ Devvit.configure({
   modLog: true,
 });
 
+const nukeFields: FormField[] = [
+  {
+    name: 'remove',
+    label: 'Remove comments',
+    type: 'boolean',
+    defaultValue: true,
+  },
+  {
+    name: 'lock',
+    label: 'Lock comments',
+    type: 'boolean',
+    defaultValue: false,
+  },
+  {
+    name: 'skipDistinguished',
+    label: 'Skip distinguished comments',
+    type: 'boolean',
+    defaultValue: false,
+  },
+] as const;
+
 const nukeForm = Devvit.createForm(
   () => {
     return {
-      fields: [
-        {
-          name: 'remove',
-          label: 'Remove comments',
-          type: 'boolean',
-          defaultValue: true,
-        },
-        {
-          name: 'lock',
-          label: 'Lock comments',
-          type: 'boolean',
-          defaultValue: false,
-        },
-        {
-          name: 'skipDistinguished',
-          label: 'Skip distinguished comments',
-          type: 'boolean',
-          defaultValue: false,
-        },
-      ],
+      fields: nukeFields,
       title: 'Mop Comments',
       acceptLabel: 'Mop',
       cancelLabel: 'Cancel',
@@ -72,26 +74,7 @@ Devvit.addMenuItem({
 const nukePostForm = Devvit.createForm(
   () => {
     return {
-      fields: [
-        {
-          name: 'remove',
-          label: 'Remove comments',
-          type: 'boolean',
-          defaultValue: true,
-        },
-        {
-          name: 'lock',
-          label: 'Lock comments',
-          type: 'boolean',
-          defaultValue: false,
-        },
-        {
-          name: 'skipDistinguished',
-          label: 'Skip distinguished comments',
-          type: 'boolean',
-          defaultValue: false,
-        },
-      ],
+      fields: nukeFields,
       title: 'Mop Post Comments',
       acceptLabel: 'Mop',
       cancelLabel: 'Cancel',

--- a/packages/apps/comment-nuke/src/main.ts
+++ b/packages/apps/comment-nuke/src/main.ts
@@ -1,11 +1,11 @@
 import { Devvit } from '@devvit/public-api';
-import { handleNuke } from './nuke.js';
-
+import { handleNuke, handleNukePost } from './nuke.js'; 
+ 
 Devvit.configure({
   redditAPI: true,
   modLog: true,
 });
-
+ 
 const nukeForm = Devvit.createForm(
   () => {
     return {
@@ -34,6 +34,7 @@ const nukeForm = Devvit.createForm(
       cancelLabel: 'Cancel',
     };
   },
+ 
   async ({ values }, context) => {
     if (context.commentId) {
       const result = await handleNuke(
@@ -53,7 +54,7 @@ const nukeForm = Devvit.createForm(
     }
   }
 );
-
+ 
 Devvit.addMenuItem({
   label: 'Mop comments',
   description: 'Remove this comment and all child comments. This might take a few seconds to run.',
@@ -63,5 +64,66 @@ Devvit.addMenuItem({
     context.ui.showForm(nukeForm);
   },
 });
-
+ 
+// Another form for nuking all comments of a post
+ 
+const nukePostForm = Devvit.createForm(
+  () => {
+    return {
+      fields: [
+        {
+          name: 'remove',
+          label: 'Remove comments',
+          type: 'boolean',
+          defaultValue: true,
+        },
+        {
+          name: 'lock',
+          label: 'Lock comments',
+          type: 'boolean',
+          defaultValue: false,
+        },
+        {
+          name: 'skipDistinguished',
+          label: 'Skip distinguished comments',
+          type: 'boolean',
+          defaultValue: false,
+        },
+      ],
+      title: 'Mop Post Comments',
+      acceptLabel: 'Mop',
+      cancelLabel: 'Cancel',
+    };
+  },
+  async ({ values }, context) => {
+    if (context.postId) {
+      const result = await handleNukePost(
+        {
+          remove: values.remove,
+          lock: values.lock,
+          skipDistinguished: values.skipDistinguished,
+          postId: context.postId,
+          subredditId: context.subredditId,
+        },
+        context
+      );
+      console.log(`Mop result - ${result.success ? 'success' : 'fail'} - ${result.message}`);
+      context.ui.showToast(`${result.success ? 'Success' : 'Failed'} : ${result.message}`);
+    } else {
+      context.ui.showToast(`Mop failed! Please try again later.`);
+    }
+  }
+);
+ 
+Devvit.addMenuItem({
+  label: 'Mop post comments',
+  description: 'Remove all comments of this post. This might take a few seconds to run.',
+  location: 'post',
+  forUserType: 'moderator',
+  onPress: (_, context) => {
+    context.ui.showForm(nukePostForm);
+  },
+});
+ 
+ 
 export default Devvit;

--- a/packages/apps/comment-nuke/src/main.ts
+++ b/packages/apps/comment-nuke/src/main.ts
@@ -3,7 +3,7 @@ import { handleNuke, handleNukePost } from './nuke.js';
 
 Devvit.configure({
   redditAPI: true,
-  // modLog: true,
+  modLog: true,
 });
 
 const nukeForm = Devvit.createForm(

--- a/packages/apps/comment-nuke/src/main.ts
+++ b/packages/apps/comment-nuke/src/main.ts
@@ -86,22 +86,22 @@ const nukePostForm = Devvit.createForm(
       return;
     }
 
-    if (context.postId) {
-      const result = await handleNukePost(
-        {
-          remove: values.remove,
-          lock: values.lock,
-          skipDistinguished: values.skipDistinguished,
-          postId: context.postId,
-          subredditId: context.subredditId,
-        },
-        context
-      );
-      console.log(`Mop result - ${result.success ? 'success' : 'fail'} - ${result.message}`);
-      context.ui.showToast(`${result.success ? 'Success' : 'Failed'} : ${result.message}`);
-    } else {
-      context.ui.showToast(`Mop failed! Please try again later.`);
+    if (!context.postId) {
+      throw new Error('No post ID');
     }
+
+    const result = await handleNukePost(
+      {
+        remove: values.remove,
+        lock: values.lock,
+        skipDistinguished: values.skipDistinguished,
+        postId: context.postId,
+        subredditId: context.subredditId,
+      },
+      context
+    );
+    console.log(`Mop result - ${result.success ? 'success' : 'fail'} - ${result.message}`);
+    context.ui.showToast(`${result.success ? 'Success' : 'Failed'} : ${result.message}`);
   }
 );
 

--- a/packages/apps/comment-nuke/src/main.ts
+++ b/packages/apps/comment-nuke/src/main.ts
@@ -1,11 +1,11 @@
 import { Devvit } from '@devvit/public-api';
-import { handleNuke, handleNukePost } from './nuke.js'; 
- 
+import { handleNuke, handleNukePost } from './nuke.js';
+
 Devvit.configure({
   redditAPI: true,
   // modLog: true,
 });
- 
+
 const nukeForm = Devvit.createForm(
   () => {
     return {
@@ -34,8 +34,12 @@ const nukeForm = Devvit.createForm(
       cancelLabel: 'Cancel',
     };
   },
- 
   async ({ values }, context) => {
+    if (!values.lock && !values.remove) {
+      context.ui.showToast('You must select either lock or remove.');
+      return;
+    }
+
     if (context.commentId) {
       const result = await handleNuke(
         {
@@ -54,7 +58,7 @@ const nukeForm = Devvit.createForm(
     }
   }
 );
- 
+
 Devvit.addMenuItem({
   label: 'Mop comments',
   description: 'Remove this comment and all child comments. This might take a few seconds to run.',
@@ -64,9 +68,7 @@ Devvit.addMenuItem({
     context.ui.showForm(nukeForm);
   },
 });
- 
-// Another form for nuking all comments of a post
- 
+
 const nukePostForm = Devvit.createForm(
   () => {
     return {
@@ -96,6 +98,11 @@ const nukePostForm = Devvit.createForm(
     };
   },
   async ({ values }, context) => {
+    if (!values.lock && !values.remove) {
+      context.ui.showToast('You must select either lock or remove.');
+      return;
+    }
+
     if (context.postId) {
       const result = await handleNukePost(
         {
@@ -114,7 +121,7 @@ const nukePostForm = Devvit.createForm(
     }
   }
 );
- 
+
 Devvit.addMenuItem({
   label: 'Mop post comments',
   description: 'Remove all comments of this post. This might take a few seconds to run.',
@@ -124,6 +131,5 @@ Devvit.addMenuItem({
     context.ui.showForm(nukePostForm);
   },
 });
- 
- 
+
 export default Devvit;

--- a/packages/apps/comment-nuke/src/nuke.ts
+++ b/packages/apps/comment-nuke/src/nuke.ts
@@ -102,7 +102,16 @@ export async function handleNukePost(props: NukePostProps, context: Devvit.Conte
       shouldLock && shouldRemove ? 'removed and locked' : shouldLock ? 'locked' : 'removed';
 
     if (shouldRemove) {
-      await removeComment(context, user, props.postId, verbage);
+      try {
+        await context.modLog.add({
+          action: 'removecomment',
+          target: props.postId,
+          details: 'comment-mop app',
+          description: `u/${user.username} used comment-mop to ${verbage} all comments of this post.`,
+        });
+      } catch (e: unknown) {
+        console.error(`Failed to add modlog for post: ${props.postId}.`, (e as Error).message);
+      }
     }
 
     success = true;
@@ -170,7 +179,16 @@ export async function handleNuke(props: NukeProps, context: Devvit.Context) {
       shouldLock && shouldRemove ? 'removed and locked' : shouldLock ? 'locked' : 'removed';
 
     if (shouldRemove) {
-      await removeComment(context, user, props.commentId, verbage);
+      try {
+        await context.modLog.add({
+          action: 'removecomment',
+          target: props.commentId,
+          details: 'comment-mop app',
+          description: `u/${user.username} used comment-mop to ${verbage} this comment and all child comments.`,
+        });
+      } catch (e: unknown) {
+        console.error(`Failed to add modlog for comment: ${props.commentId}.`, (e as Error).message);
+      }
     }
 
     success = true;

--- a/packages/apps/comment-nuke/src/nuke.ts
+++ b/packages/apps/comment-nuke/src/nuke.ts
@@ -1,5 +1,5 @@
 import { Comment, Devvit, Post } from '@devvit/public-api';
- 
+
 export type NukeProps = {
   remove: boolean;
   lock: boolean;
@@ -7,231 +7,206 @@ export type NukeProps = {
   commentId: string;
   subredditId: string;
 };
- 
+
 export type NukePostProps = {
-    remove: boolean;
-    lock: boolean;
-    skipDistinguished: boolean;
-    postId: string;
-    subredditId: string;
-  };
- 
-   async function getAllCommentsInPost(
-    post: Post,
-    result: Comment[] = []
-  ): Promise<Comment[]> {
-    const comments = await post.comments.all();
-    if (comments.length > 0) {
-      for (const comment of comments) {
-        await getAllCommentsInThread(comment, result);
-      }
-    }
-    return result;
-  }
-  
-  export async function handleNukePost(props: NukePostProps, context: Devvit.Context) {
-    const startTime = new Date();
-    let success = true;
-    let message: string;
-  
-    const shouldLock = props.lock;
-    const shouldRemove = props.remove;
-    const skipDistinguished = props.skipDistinguished;
-  
-    if (!shouldLock && !shouldRemove) {
-      return { message: 'You must select either lock or remove.', success: false };
-    }
-  
-    try {
-      const post = await context.reddit.getPostById(props.postId);
-      const user = await context.reddit.getCurrentUser();
-      const modPermissions = await user.getModPermissionsForSubreddit(post.subredditName);
-      const canManagePosts = modPermissions.includes('all') || modPermissions.includes('posts');
- 
-      console.log(
-        `Mod Info: r/${post.subredditName} u/${user.username} permissions:${modPermissions}: ${
-          canManagePosts ? 'Can mod' : 'Cannot mod'
-        }`
-      );
-  
-      if (!canManagePosts) {
-        console.info('A user without the correct mod permissions tried to nuke all comments of a post.');
-        return {
-          message: 'You do you not have the correct mod permissions to do this.',
-          success: false,
-        };
-      }
-  
-      const allComments = await getAllCommentsInPost(post);
-      const comments = allComments.filter(
-        (eachComment: any) => !(skipDistinguished && eachComment.isDistinguished())
-      );
-  
-      const lockPromises: Promise<any>[] = [];
-      const removePromises: Promise<any>[] = [];
-  
-      for (const eachComment of comments) {
-        const commentId = eachComment.id;
-        if (shouldLock && !eachComment.locked) {
-          lockPromises.push(eachComment.lock());
-        }
-  
-        if (shouldRemove && !eachComment.removed) {
-          removePromises.push(eachComment.remove());
-        }
-      }
-      const responses = await Promise.all([...removePromises, ...lockPromises]);
-  
-      for (const r of responses) {
-        if (r && r.status === 'rejected') {
-          console.error('Failed to remove or lock a comment.');
-          console.info(r.reason);
-        }
-      }
-  
-      const verbage =
-        shouldLock && shouldRemove ? 'removed and locked' : shouldLock ? 'locked' : 'removed';
-  
-      if (shouldRemove) {
-        const postId = props.postId;
-        await context.modLog
-          .add({
-            action: 'removecomment',
-            target: postId,
-            details: 'comment-mop app',
-            description: `u/${user.username} used comment-mop to ${verbage} all comments of this post.`,
-          })
-          .catch((e: any) =>
-            console.error(`Failed to add modlog for post: ${postId}.`, e.message)
-          );
-      }
-  
-      success = true;
-      message = `${comments.length} comment${
-        comments.length > 1 ? 's' : ''
-      } ${verbage}! Refresh the page to see the cleanup.`;
-  
-      const finishTime = new Date();
-      const timeElapsed = (finishTime as any) - (startTime as any);
-      console.info(`${comments.length} comment(s) handled in ${timeElapsed / 1000} seconds.`);
-    } catch (err: any) {
-      success = false;
-      message = 'Mop failed! Please try again later.';
-      console.error(`${err.toString()}`);
-    }
-  
-    return { success, message };
-  }
- 
-async function getAllCommentsInThread(
-  comment: Comment,
-  result: Comment[] = []
-): Promise<Comment[]> {
-  result.push(comment);
+  remove: boolean;
+  lock: boolean;
+  skipDistinguished: boolean;
+  postId: string;
+  subredditId: string;
+};
+
+async function* getAllCommentsInThread(comment: Comment): AsyncGenerator<Comment> {
   const replies = await comment.replies.all();
-  // console.log(`added comment - ${comment.id} - ${comment.body} - replies: ${replies.length}`);
-  if (replies.length > 0) {
-    for (const reply of replies) {
-      await getAllCommentsInThread(reply, result);
-    }
+  for (const reply of replies) {
+    yield* getAllCommentsInThread(reply);
+    yield reply;
   }
-  return result;
 }
- 
-export async function handleNuke(props: NukeProps, context: Devvit.Context) {
+
+async function* getAllCommentsInPost(post: Post): AsyncGenerator<Comment> {
+  const comments = await post.comments.all();
+  for (const comment of comments) {
+    yield* getAllCommentsInThread(comment);
+    yield comment;
+  }
+}
+
+export async function handleNukePost(props: NukePostProps, context: Devvit.Context) {
   const startTime = new Date();
   let success = true;
   let message: string;
- 
+
   const shouldLock = props.lock;
   const shouldRemove = props.remove;
   const skipDistinguished = props.skipDistinguished;
- 
+
   if (!shouldLock && !shouldRemove) {
     return { message: 'You must select either lock or remove.', success: false };
   }
- 
+
   try {
-    const comment = await context.reddit.getCommentById(props.commentId);
+    const post = await context.reddit.getPostById(props.postId);
     const user = await context.reddit.getCurrentUser();
-    const modPermissions = await user.getModPermissionsForSubreddit(comment.subredditName);
+    const modPermissions = await user.getModPermissionsForSubreddit(post.subredditName);
     const canManagePosts = modPermissions.includes('all') || modPermissions.includes('posts');
- 
+
     console.log(
-      `Mod Info: r/${comment.subredditName} u/${user.username} permissions:${modPermissions}: ${
+      `Mod Info: r/${post.subredditName} u/${user.username} permissions:${modPermissions}: ${
         canManagePosts ? 'Can mod' : 'Cannot mod'
       }`
     );
- 
+
     if (!canManagePosts) {
-      console.info('A user without the correct mod permissions tried to comment mop.');
+      console.info('A user without the correct mod permissions tried to nuke all comments of a post.');
       return {
-        message: 'You do you not have the correct mod permissions to do this.',
+        message: 'You do not have the correct mod permissions to do this.',
         success: false,
       };
     }
- 
-    const allComments = await getAllCommentsInThread(comment);
-    const comments = allComments.filter(
-      (eachComment) => !(skipDistinguished && eachComment.isDistinguished())
-    );
- 
-    // Build lock and remove promise arrays
+    
+
     const lockPromises: Promise<any>[] = [];
     const removePromises: Promise<any>[] = [];
- 
-    for (const eachComment of comments) {
-      const commentId = eachComment.id;
+
+    for await (const eachComment of getAllCommentsInPost(post)) {
+      if (skipDistinguished && eachComment.isDistinguished()) {
+        continue;
+      }
+
       if (shouldLock && !eachComment.locked) {
-        console.info(`Locking comment ${commentId}.`);
         lockPromises.push(eachComment.lock());
       }
- 
+
       if (shouldRemove && !eachComment.removed) {
-        console.info(`Removing comment ${commentId}.`);
         removePromises.push(eachComment.remove());
       }
     }
+
     const responses = await Promise.all([...removePromises, ...lockPromises]);
- 
+
     for (const r of responses) {
       if (r && r.status === 'rejected') {
         console.error('Failed to remove or lock a comment.');
         console.info(r.reason);
       }
     }
- 
+
     const verbage =
       shouldLock && shouldRemove ? 'removed and locked' : shouldLock ? 'locked' : 'removed';
- 
+
     if (shouldRemove) {
-      const commentId = props.commentId;
+      /*
       await context.modLog
         .add({
           action: 'removecomment',
-          target: commentId,
+          target: props.postId,
+          details: 'comment-mop app',
+          description: `u/${user.username} used comment-mop to ${verbage} all comments of this post.`,
+        })
+        .catch((e: any) =>
+          console.error(`Failed to add modlog for post: ${props.postId}.`, e.message)
+        );
+        */
+    }
+
+    success = true;
+    message = `Comments ${verbage}! Refresh the page to see the cleanup.`;
+    const finishTime = new Date();
+    console.info(`Operation completed in ${(finishTime.getTime() - startTime.getTime()) / 1000} seconds.`);
+  } catch (err: any) {
+    success = false;
+    message = 'Mop failed! Please try again later.';
+    console.error(err);
+  }
+
+  return { success, message };
+}
+
+export async function handleNuke(props: NukeProps, context: Devvit.Context) {
+  const startTime = new Date();
+  let success = true;
+  let message: string;
+
+  const shouldLock = props.lock;
+  const shouldRemove = props.remove;
+  const skipDistinguished = props.skipDistinguished;
+
+  if (!shouldLock && !shouldRemove) {
+    return { message: 'You must select either lock or remove.', success: false };
+  }
+
+  try {
+    const comment = await context.reddit.getCommentById(props.commentId);
+    const user = await context.reddit.getCurrentUser();
+    const modPermissions = await user.getModPermissionsForSubreddit(comment.subredditName);
+    const canManagePosts = modPermissions.includes('all') || modPermissions.includes('posts');
+
+    console.log(
+      `Mod Info: r/${comment.subredditName} u/${user.username} permissions:${modPermissions}: ${
+        canManagePosts ? 'Can mod' : 'Cannot mod'
+      }`
+    );
+
+    if (!canManagePosts) {
+      console.info('A user without the correct mod permissions tried to comment mop.');
+      return {
+        message: 'You do not have the correct mod permissions to do this.',
+        success: false,
+      };
+    }
+
+    const lockPromises: Promise<any>[] = [];
+    const removePromises: Promise<any>[] = [];
+
+    for await (const eachComment of getAllCommentsInThread(comment)) {
+      if (skipDistinguished && eachComment.isDistinguished()) {
+        continue;
+      }
+
+      if (shouldLock && !eachComment.locked) {
+        lockPromises.push(eachComment.lock());
+      }
+
+      if (shouldRemove && !eachComment.removed) {
+        removePromises.push(eachComment.remove());
+      }
+    }
+
+    const responses = await Promise.all([...removePromises, ...lockPromises]);
+
+    for (const r of responses) {
+      if (r && r.status === 'rejected') {
+        console.error('Failed to remove or lock a comment.');
+        console.info(r.reason);
+      }
+    }
+
+    const verbage =
+      shouldLock && shouldRemove ? 'removed and locked' : shouldLock ? 'locked' : 'removed';
+
+    if (shouldRemove) {
+      /* await context.modLog
+        .add({
+          action: 'removecomment',
+          target: props.commentId,
           details: 'comment-mop app',
           description: `u/${user.username} used comment-mop to ${verbage} this comment and all child comments.`,
         })
         .catch((e: any) =>
-          console.error(`Failed to add modlog for comment: ${commentId}.`, e.message)
-        );
+          console.error(`Failed to add modlog for comment: ${props.commentId}.`, e.message)
+        ); */
     }
- 
+
     success = true;
-    message = `${comments.length} comment${
-      comments.length > 1 ? 's' : ''
-    } ${verbage}! Refresh the page to see the cleanup.`;
- 
-    // Log out how long the action took to run.
+    message = `Comments ${verbage}! Refresh the page to see the cleanup.`;
     const finishTime = new Date();
-    const timeElapsed = (finishTime as any) - (startTime as any);
-    console.info(`${comments.length} comment(s) handled in ${timeElapsed / 1000} seconds.`);
+    console.info(`Operation completed in ${(finishTime.getTime() - startTime.getTime()) / 1000} seconds.`);
   } catch (err: any) {
     success = false;
     message = 'Mop failed! Please try again later.';
-    console.error(`${err.toString()}`);
+    console.error(err);
   }
- 
+
   return { success, message };
 }

--- a/packages/apps/comment-nuke/src/nuke.ts
+++ b/packages/apps/comment-nuke/src/nuke.ts
@@ -203,3 +203,4 @@ export async function handleNuke(props: NukeProps, context: Devvit.Context) {
 
   return { success, message };
 }
+

--- a/packages/apps/comment-nuke/src/nuke.ts
+++ b/packages/apps/comment-nuke/src/nuke.ts
@@ -3,7 +3,7 @@ import { Comment, Devvit, Post } from '@devvit/public-api';
 export type NukeProps = {
   remove: boolean;
   lock: boolean;
-  skipDistinguished: boolean;
+  skipDistinguished: boolean; // When true, distinguished comments and their children are not processed
   commentId: string;
   subredditId: string;
 };
@@ -11,7 +11,7 @@ export type NukeProps = {
 export type NukePostProps = {
   remove: boolean;
   lock: boolean;
-  skipDistinguished: boolean;
+  skipDistinguished: boolean; // When true, distinguished comments and their children are not processed
   postId: string;
   subredditId: string;
 };

--- a/packages/apps/comment-nuke/src/nuke.ts
+++ b/packages/apps/comment-nuke/src/nuke.ts
@@ -89,18 +89,16 @@ export async function handleNukePost(props: NukePostProps, context: Devvit.Conte
       shouldLock && shouldRemove ? 'removed and locked' : shouldLock ? 'locked' : 'removed';
 
     if (shouldRemove) {
-      /*
-      await context.modLog
-        .add({
+      /* try {
+        await context.modLog.add({
           action: 'removecomment',
           target: props.postId,
           details: 'comment-mop app',
           description: `u/${user.username} used comment-mop to ${verbage} all comments of this post.`,
-        })
-        .catch((e: any) =>
-          console.error(`Failed to add modlog for post: ${props.postId}.`, e.message)
-        );
-        */
+        });
+      } catch (e: any) {
+        console.error(`Failed to add modlog for post: ${props.postId}.`, e.message);
+      } */
     }
 
     success = true;
@@ -167,16 +165,16 @@ export async function handleNuke(props: NukeProps, context: Devvit.Context) {
       shouldLock && shouldRemove ? 'removed and locked' : shouldLock ? 'locked' : 'removed';
 
     if (shouldRemove) {
-      /* await context.modLog
-        .add({
+      /* try {
+        await context.modLog.add({
           action: 'removecomment',
           target: props.commentId,
           details: 'comment-mop app',
           description: `u/${user.username} used comment-mop to ${verbage} this comment and all child comments.`,
-        })
-        .catch((e: any) =>
-          console.error(`Failed to add modlog for comment: ${props.commentId}.`, e.message)
-        ); */
+        });
+      } catch (e: any) {
+        console.error(`Failed to add modlog for comment: ${props.commentId}.`, e.message);
+      } */
     }
 
     success = true;

--- a/packages/apps/comment-nuke/src/nuke.ts
+++ b/packages/apps/comment-nuke/src/nuke.ts
@@ -36,6 +36,19 @@ async function* getAllCommentsInPost(post: Post, skipDistinguished: boolean): As
   }
 }
 
+async function removeComment(context: Devvit.Context, user: any, targetId: string, verbage: string) {
+  try {
+    await context.modLog.add({
+      action: 'removecomment',
+      target: targetId,
+      details: 'comment-mop app',
+      description: `u/${user.username} used comment-mop to ${verbage} this comment and all child comments.`,
+    });
+  } catch (e: any) {
+    console.error(`Failed to add modlog for comment: ${targetId}.`, e.message);
+  }
+}
+
 export async function handleNukePost(props: NukePostProps, context: Devvit.Context) {
   const startTime = new Date();
   let success = true;
@@ -89,16 +102,7 @@ export async function handleNukePost(props: NukePostProps, context: Devvit.Conte
       shouldLock && shouldRemove ? 'removed and locked' : shouldLock ? 'locked' : 'removed';
 
     if (shouldRemove) {
-      /* try {
-        await context.modLog.add({
-          action: 'removecomment',
-          target: props.postId,
-          details: 'comment-mop app',
-          description: `u/${user.username} used comment-mop to ${verbage} all comments of this post.`,
-        });
-      } catch (e: any) {
-        console.error(`Failed to add modlog for post: ${props.postId}.`, e.message);
-      } */
+      await removeComment(context, user, props.postId, verbage);
     }
 
     success = true;
@@ -165,16 +169,7 @@ export async function handleNuke(props: NukeProps, context: Devvit.Context) {
       shouldLock && shouldRemove ? 'removed and locked' : shouldLock ? 'locked' : 'removed';
 
     if (shouldRemove) {
-      /* try {
-        await context.modLog.add({
-          action: 'removecomment',
-          target: props.commentId,
-          details: 'comment-mop app',
-          description: `u/${user.username} used comment-mop to ${verbage} this comment and all child comments.`,
-        });
-      } catch (e: any) {
-        console.error(`Failed to add modlog for comment: ${props.commentId}.`, e.message);
-      } */
+      await removeComment(context, user, props.commentId, verbage);
     }
 
     success = true;

--- a/packages/apps/comment-nuke/src/nuke.ts
+++ b/packages/apps/comment-nuke/src/nuke.ts
@@ -41,10 +41,6 @@ export async function handleNukePost(props: NukePostProps, context: Devvit.Conte
   const shouldRemove = props.remove;
   const skipDistinguished = props.skipDistinguished;
 
-  if (!shouldLock && !shouldRemove) {
-    return { message: 'You must select either lock or remove.', success: false };
-  }
-
   try {
     const post = await context.reddit.getPostById(props.postId);
     const user = await context.reddit.getCurrentUser();
@@ -64,7 +60,6 @@ export async function handleNukePost(props: NukePostProps, context: Devvit.Conte
         success: false,
       };
     }
-    
 
     const lockPromises: Promise<any>[] = [];
     const removePromises: Promise<any>[] = [];
@@ -131,10 +126,6 @@ export async function handleNuke(props: NukeProps, context: Devvit.Context) {
   const shouldLock = props.lock;
   const shouldRemove = props.remove;
   const skipDistinguished = props.skipDistinguished;
-
-  if (!shouldLock && !shouldRemove) {
-    return { message: 'You must select either lock or remove.', success: false };
-  }
 
   try {
     const comment = await context.reddit.getCommentById(props.commentId);

--- a/packages/apps/comment-nuke/src/nuke.ts
+++ b/packages/apps/comment-nuke/src/nuke.ts
@@ -72,23 +72,18 @@ export async function handleNukePost(props: NukePostProps, context: Devvit.Conte
       };
     }
 
-    const lockPromises: Promise<void>[] = [];
-    const removePromises: Promise<void>[] = [];
-
+    const comments: Comment[] = [];
     for await (const eachComment of getAllCommentsInPost(post, skipDistinguished)) {
-      if (shouldLock && !eachComment.locked) {
-        lockPromises.push(eachComment.lock());
-      }
-
-      if (shouldRemove && !eachComment.removed) {
-        removePromises.push(eachComment.remove());
-      }
+      comments.push(eachComment);
     }
 
-    await Promise.all([...removePromises, ...lockPromises]).catch((err) => {
-      console.error('Failed to remove or lock a comment.');
-      console.error(err);
-    });
+    if (shouldLock) {
+      await Promise.all(comments.map(comment => comment.locked || comment.lock()));
+    }
+
+    if (shouldRemove) {
+      await Promise.all(comments.map(comment => comment.removed || comment.remove()));
+    }
 
     const verbage =
       shouldLock && shouldRemove ? 'removed and locked' : shouldLock ? 'locked' : 'removed';
@@ -155,23 +150,18 @@ export async function handleNuke(props: NukeProps, context: Devvit.Context) {
       };
     }
 
-    const lockPromises: Promise<void>[] = [];
-    const removePromises: Promise<void>[] = [];
-
+    const comments: Comment[] = [];
     for await (const eachComment of getAllCommentsInThread(comment, skipDistinguished)) {
-      if (shouldLock && !eachComment.locked) {
-        lockPromises.push(eachComment.lock());
-      }
-
-      if (shouldRemove && !eachComment.removed) {
-        removePromises.push(eachComment.remove());
-      }
+      comments.push(eachComment);
     }
 
-    await Promise.all([...removePromises, ...lockPromises]).catch((err) => {
-      console.error('Failed to remove or lock a comment.');
-      console.error(err);
-    });
+    if (shouldLock) {
+      await Promise.all(comments.map(comment => comment.locked || comment.lock()));
+    }
+
+    if (shouldRemove) {
+      await Promise.all(comments.map(comment => comment.removed || comment.remove()));
+    }
 
     const verbage =
       shouldLock && shouldRemove ? 'removed and locked' : shouldLock ? 'locked' : 'removed';

--- a/packages/apps/comment-nuke/src/nuke.ts
+++ b/packages/apps/comment-nuke/src/nuke.ts
@@ -50,7 +50,7 @@ async function removeComment(context: Devvit.Context, user: any, targetId: strin
 }
 
 export async function handleNukePost(props: NukePostProps, context: Devvit.Context) {
-  const startTime = new Date();
+  const startTime = Date.now();
   let success = true;
   let message: string;
 
@@ -107,8 +107,9 @@ export async function handleNukePost(props: NukePostProps, context: Devvit.Conte
 
     success = true;
     message = `Comments ${verbage}! Refresh the page to see the cleanup.`;
-    const finishTime = new Date();
-    console.info(`Operation completed in ${(finishTime.getTime() - startTime.getTime()) / 1000} seconds.`);
+    const finishTime = Date.now();
+    const timeElapsed = (finishTime - startTime) / 1000;
+    console.info(`Operation completed in ${timeElapsed} seconds.`);
   } catch (err: any) {
     success = false;
     message = 'Mop failed! Please try again later.';
@@ -119,7 +120,7 @@ export async function handleNukePost(props: NukePostProps, context: Devvit.Conte
 }
 
 export async function handleNuke(props: NukeProps, context: Devvit.Context) {
-  const startTime = new Date();
+  const startTime = Date.now();
   let success = true;
   let message: string;
 
@@ -174,8 +175,9 @@ export async function handleNuke(props: NukeProps, context: Devvit.Context) {
 
     success = true;
     message = `Comments ${verbage}! Refresh the page to see the cleanup.`;
-    const finishTime = new Date();
-    console.info(`Operation completed in ${(finishTime.getTime() - startTime.getTime()) / 1000} seconds.`);
+    const finishTime = Date.now();
+    const timeElapsed = (finishTime - startTime) / 1000;
+    console.info(`Operation completed in ${timeElapsed} seconds.`);
   } catch (err: any) {
     success = false;
     message = 'Mop failed! Please try again later.';

--- a/packages/apps/comment-nuke/src/nuke.ts
+++ b/packages/apps/comment-nuke/src/nuke.ts
@@ -67,8 +67,8 @@ export async function handleNukePost(props: NukePostProps, context: Devvit.Conte
       };
     }
 
-    const lockPromises: Promise<any>[] = [];
-    const removePromises: Promise<any>[] = [];
+    const lockPromises: Promise<void>[] = [];
+    const removePromises: Promise<void>[] = [];
 
     for await (const eachComment of getAllCommentsInPost(post, skipDistinguished)) {
       if (shouldLock && !eachComment.locked) {
@@ -80,14 +80,10 @@ export async function handleNukePost(props: NukePostProps, context: Devvit.Conte
       }
     }
 
-    const responses = await Promise.all([...removePromises, ...lockPromises]);
-
-    for (const r of responses) {
-      if (r && r.status === 'rejected') {
-        console.error('Failed to remove or lock a comment.');
-        console.info(r.reason);
-      }
-    }
+    await Promise.all([...removePromises, ...lockPromises]).catch((error) => {
+      console.error('Failed to remove or lock a comment.');
+      console.info(error.message);
+    });
 
     const verbage =
       shouldLock && shouldRemove ? 'removed and locked' : shouldLock ? 'locked' : 'removed';
@@ -149,8 +145,8 @@ export async function handleNuke(props: NukeProps, context: Devvit.Context) {
       };
     }
 
-    const lockPromises: Promise<any>[] = [];
-    const removePromises: Promise<any>[] = [];
+    const lockPromises: Promise<void>[] = [];
+    const removePromises: Promise<void>[] = [];
 
     for await (const eachComment of getAllCommentsInThread(comment, skipDistinguished)) {
       if (shouldLock && !eachComment.locked) {
@@ -162,14 +158,10 @@ export async function handleNuke(props: NukeProps, context: Devvit.Context) {
       }
     }
 
-    const responses = await Promise.all([...removePromises, ...lockPromises]);
-
-    for (const r of responses) {
-      if (r && r.status === 'rejected') {
-        console.error('Failed to remove or lock a comment.');
-        console.info(r.reason);
-      }
-    }
+    await Promise.all([...removePromises, ...lockPromises]).catch((error) => {
+      console.error('Failed to remove or lock a comment.');
+      console.info(error.message);
+    });
 
     const verbage =
       shouldLock && shouldRemove ? 'removed and locked' : shouldLock ? 'locked' : 'removed';
@@ -198,4 +190,4 @@ export async function handleNuke(props: NukeProps, context: Devvit.Context) {
   }
 
   return { success, message };
-} 
+}

--- a/packages/apps/comment-nuke/src/nuke.ts
+++ b/packages/apps/comment-nuke/src/nuke.ts
@@ -1,5 +1,5 @@
-import { Comment, Devvit } from '@devvit/public-api';
-
+import { Comment, Devvit, Post } from '@devvit/public-api';
+ 
 export type NukeProps = {
   remove: boolean;
   lock: boolean;
@@ -7,7 +7,122 @@ export type NukeProps = {
   commentId: string;
   subredditId: string;
 };
-
+ 
+export type NukePostProps = {
+    remove: boolean;
+    lock: boolean;
+    skipDistinguished: boolean;
+    postId: string;
+    subredditId: string;
+  };
+ 
+   async function getAllCommentsInPost(
+    post: Post,
+    result: Comment[] = []
+  ): Promise<Comment[]> {
+    const comments = await post.comments.all();
+    if (comments.length > 0) {
+      for (const comment of comments) {
+        await getAllCommentsInThread(comment, result);
+      }
+    }
+    return result;
+  }
+  
+  export async function handleNukePost(props: NukePostProps, context: Devvit.Context) {
+    const startTime = new Date();
+    let success = true;
+    let message: string;
+  
+    const shouldLock = props.lock;
+    const shouldRemove = props.remove;
+    const skipDistinguished = props.skipDistinguished;
+  
+    if (!shouldLock && !shouldRemove) {
+      return { message: 'You must select either lock or remove.', success: false };
+    }
+  
+    try {
+      const post = await context.reddit.getPostById(props.postId);
+      const user = await context.reddit.getCurrentUser();
+      const modPermissions = await user.getModPermissionsForSubreddit(post.subredditName);
+      const canManagePosts = modPermissions.includes('all') || modPermissions.includes('posts');
+ 
+      console.log(
+        `Mod Info: r/${post.subredditName} u/${user.username} permissions:${modPermissions}: ${
+          canManagePosts ? 'Can mod' : 'Cannot mod'
+        }`
+      );
+  
+      if (!canManagePosts) {
+        console.info('A user without the correct mod permissions tried to nuke all comments of a post.');
+        return {
+          message: 'You do you not have the correct mod permissions to do this.',
+          success: false,
+        };
+      }
+  
+      const allComments = await getAllCommentsInPost(post);
+      const comments = allComments.filter(
+        (eachComment: any) => !(skipDistinguished && eachComment.isDistinguished())
+      );
+  
+      const lockPromises: Promise<any>[] = [];
+      const removePromises: Promise<any>[] = [];
+  
+      for (const eachComment of comments) {
+        const commentId = eachComment.id;
+        if (shouldLock && !eachComment.locked) {
+          lockPromises.push(eachComment.lock());
+        }
+  
+        if (shouldRemove && !eachComment.removed) {
+          removePromises.push(eachComment.remove());
+        }
+      }
+      const responses = await Promise.all([...removePromises, ...lockPromises]);
+  
+      for (const r of responses) {
+        if (r && r.status === 'rejected') {
+          console.error('Failed to remove or lock a comment.');
+          console.info(r.reason);
+        }
+      }
+  
+      const verbage =
+        shouldLock && shouldRemove ? 'removed and locked' : shouldLock ? 'locked' : 'removed';
+  
+      if (shouldRemove) {
+        const postId = props.postId;
+        await context.modLog
+          .add({
+            action: 'removecomment',
+            target: postId,
+            details: 'comment-mop app',
+            description: `u/${user.username} used comment-mop to ${verbage} all comments of this post.`,
+          })
+          .catch((e: any) =>
+            console.error(`Failed to add modlog for post: ${postId}.`, e.message)
+          );
+      }
+  
+      success = true;
+      message = `${comments.length} comment${
+        comments.length > 1 ? 's' : ''
+      } ${verbage}! Refresh the page to see the cleanup.`;
+  
+      const finishTime = new Date();
+      const timeElapsed = (finishTime as any) - (startTime as any);
+      console.info(`${comments.length} comment(s) handled in ${timeElapsed / 1000} seconds.`);
+    } catch (err: any) {
+      success = false;
+      message = 'Mop failed! Please try again later.';
+      console.error(`${err.toString()}`);
+    }
+  
+    return { success, message };
+  }
+ 
 async function getAllCommentsInThread(
   comment: Comment,
   result: Comment[] = []
@@ -22,32 +137,32 @@ async function getAllCommentsInThread(
   }
   return result;
 }
-
+ 
 export async function handleNuke(props: NukeProps, context: Devvit.Context) {
   const startTime = new Date();
   let success = true;
   let message: string;
-
+ 
   const shouldLock = props.lock;
   const shouldRemove = props.remove;
   const skipDistinguished = props.skipDistinguished;
-
+ 
   if (!shouldLock && !shouldRemove) {
     return { message: 'You must select either lock or remove.', success: false };
   }
-
+ 
   try {
     const comment = await context.reddit.getCommentById(props.commentId);
     const user = await context.reddit.getCurrentUser();
     const modPermissions = await user.getModPermissionsForSubreddit(comment.subredditName);
     const canManagePosts = modPermissions.includes('all') || modPermissions.includes('posts');
-
+ 
     console.log(
       `Mod Info: r/${comment.subredditName} u/${user.username} permissions:${modPermissions}: ${
         canManagePosts ? 'Can mod' : 'Cannot mod'
       }`
     );
-
+ 
     if (!canManagePosts) {
       console.info('A user without the correct mod permissions tried to comment mop.');
       return {
@@ -55,40 +170,40 @@ export async function handleNuke(props: NukeProps, context: Devvit.Context) {
         success: false,
       };
     }
-
+ 
     const allComments = await getAllCommentsInThread(comment);
     const comments = allComments.filter(
       (eachComment) => !(skipDistinguished && eachComment.isDistinguished())
     );
-
+ 
     // Build lock and remove promise arrays
     const lockPromises: Promise<any>[] = [];
     const removePromises: Promise<any>[] = [];
-
+ 
     for (const eachComment of comments) {
       const commentId = eachComment.id;
       if (shouldLock && !eachComment.locked) {
         console.info(`Locking comment ${commentId}.`);
         lockPromises.push(eachComment.lock());
       }
-
+ 
       if (shouldRemove && !eachComment.removed) {
         console.info(`Removing comment ${commentId}.`);
         removePromises.push(eachComment.remove());
       }
     }
     const responses = await Promise.all([...removePromises, ...lockPromises]);
-
+ 
     for (const r of responses) {
       if (r && r.status === 'rejected') {
         console.error('Failed to remove or lock a comment.');
         console.info(r.reason);
       }
     }
-
+ 
     const verbage =
       shouldLock && shouldRemove ? 'removed and locked' : shouldLock ? 'locked' : 'removed';
-
+ 
     if (shouldRemove) {
       const commentId = props.commentId;
       await context.modLog
@@ -102,12 +217,12 @@ export async function handleNuke(props: NukeProps, context: Devvit.Context) {
           console.error(`Failed to add modlog for comment: ${commentId}.`, e.message)
         );
     }
-
+ 
     success = true;
     message = `${comments.length} comment${
       comments.length > 1 ? 's' : ''
     } ${verbage}! Refresh the page to see the cleanup.`;
-
+ 
     // Log out how long the action took to run.
     const finishTime = new Date();
     const timeElapsed = (finishTime as any) - (startTime as any);
@@ -117,6 +232,6 @@ export async function handleNuke(props: NukeProps, context: Devvit.Context) {
     message = 'Mop failed! Please try again later.';
     console.error(`${err.toString()}`);
   }
-
+ 
   return { success, message };
 }

--- a/packages/apps/comment-nuke/src/nuke.ts
+++ b/packages/apps/comment-nuke/src/nuke.ts
@@ -85,12 +85,10 @@ export async function handleNukePost(props: NukePostProps, context: Devvit.Conte
       }
     }
 
-    try {
-      await Promise.all([...removePromises, ...lockPromises]);
-    } catch (err) {
+    await Promise.all([...removePromises, ...lockPromises]).catch((err) => {
       console.error('Failed to remove or lock a comment.');
-      console.info(err);
-    }
+      console.error(err);
+    });
 
     const verbage =
       shouldLock && shouldRemove ? 'removed and locked' : shouldLock ? 'locked' : 'removed';
@@ -170,14 +168,10 @@ export async function handleNuke(props: NukeProps, context: Devvit.Context) {
       }
     }
 
-    const responses = await Promise.allSettled([...removePromises, ...lockPromises]);
-
-    for (const r of responses) {
-      if (r.status === 'rejected') {
-        console.error('Failed to remove or lock a comment.');
-        console.info(r.reason);
-      }
-    }
+    await Promise.all([...removePromises, ...lockPromises]).catch((err) => {
+      console.error('Failed to remove or lock a comment.');
+      console.error(err);
+    });
 
     const verbage =
       shouldLock && shouldRemove ? 'removed and locked' : shouldLock ? 'locked' : 'removed';

--- a/packages/apps/comment-nuke/src/nuke.ts
+++ b/packages/apps/comment-nuke/src/nuke.ts
@@ -42,8 +42,10 @@ export async function handleNukePost(props: NukePostProps, context: Devvit.Conte
   const skipDistinguished = props.skipDistinguished;
 
   try {
-    const post = await context.reddit.getPostById(props.postId);
-    const user = await context.reddit.getCurrentUser();
+    const [user, post] = await Promise.all([
+      context.reddit.getCurrentUser(),
+      context.reddit.getPostById(props.postId)
+    ]);
     const modPermissions = await user.getModPermissionsForSubreddit(post.subredditName);
     const canManagePosts = modPermissions.includes('all') || modPermissions.includes('posts');
 

--- a/packages/apps/comment-nuke/src/nuke.ts
+++ b/packages/apps/comment-nuke/src/nuke.ts
@@ -16,6 +16,7 @@ export type NukePostProps = {
   subredditId: string;
 };
 
+// Depth-first traversal to get all comments in a thread
 async function* getAllCommentsInThread(comment: Comment, skipDistinguished: boolean): AsyncGenerator<Comment> {
   const replies = await comment.replies.all();
   for (const reply of replies) {
@@ -26,6 +27,7 @@ async function* getAllCommentsInThread(comment: Comment, skipDistinguished: bool
   }
 }
 
+// Depth-first traversal to get all comments in a thread
 async function* getAllCommentsInPost(post: Post, skipDistinguished: boolean): AsyncGenerator<Comment> {
   const comments = await post.comments.all();
   for (const comment of comments) {

--- a/packages/apps/comment-nuke/src/nuke.ts
+++ b/packages/apps/comment-nuke/src/nuke.ts
@@ -27,7 +27,7 @@ async function* getAllCommentsInThread(comment: Comment, skipDistinguished: bool
   }
 }
 
-// Depth-first traversal to get all comments in a thread
+// Depth-first traversal to get all comments in a post
 async function* getAllCommentsInPost(post: Post, skipDistinguished: boolean): AsyncGenerator<Comment> {
   const comments = await post.comments.all();
   for (const comment of comments) {
@@ -35,19 +35,6 @@ async function* getAllCommentsInPost(post: Post, skipDistinguished: boolean): As
       yield* getAllCommentsInThread(comment, skipDistinguished);
       yield comment;
     }
-  }
-}
-
-async function removeComment(context: Devvit.Context, user: any, targetId: string, verbage: string) {
-  try {
-    await context.modLog.add({
-      action: 'removecomment',
-      target: targetId,
-      details: 'comment-mop app',
-      description: `u/${user.username} used comment-mop to ${verbage} this comment and all child comments.`,
-    });
-  } catch (e: unknown) {
-    console.error(`Failed to add modlog for comment: ${targetId}.`, (e as Error).message);
   }
 }
 

--- a/packages/apps/comment-nuke/src/nuke.ts
+++ b/packages/apps/comment-nuke/src/nuke.ts
@@ -44,8 +44,8 @@ async function removeComment(context: Devvit.Context, user: any, targetId: strin
       details: 'comment-mop app',
       description: `u/${user.username} used comment-mop to ${verbage} this comment and all child comments.`,
     });
-  } catch (e: any) {
-    console.error(`Failed to add modlog for comment: ${targetId}.`, e.message);
+  } catch (e: unknown) {
+    console.error(`Failed to add modlog for comment: ${targetId}.`, (e as Error).message);
   }
 }
 
@@ -109,8 +109,8 @@ export async function handleNukePost(props: NukePostProps, context: Devvit.Conte
     message = `Comments ${verbage}! Refresh the page to see the cleanup.`;
     const finishTime = Date.now();
     const timeElapsed = (finishTime - startTime) / 1000;
-    console.info(`Operation completed in ${timeElapsed} seconds.`);
-  } catch (err: any) {
+    console.info(`${comments.length} comment(s) handled in ${timeElapsed} seconds.`);
+  } catch (err: unknown) {
     success = false;
     message = 'Mop failed! Please try again later.';
     console.error(err);
@@ -177,8 +177,8 @@ export async function handleNuke(props: NukeProps, context: Devvit.Context) {
     message = `Comments ${verbage}! Refresh the page to see the cleanup.`;
     const finishTime = Date.now();
     const timeElapsed = (finishTime - startTime) / 1000;
-    console.info(`Operation completed in ${timeElapsed} seconds.`);
-  } catch (err: any) {
+    console.info(`${comments.length} comment(s) handled in ${timeElapsed} seconds.`);
+  } catch (err: unknown) {
     success = false;
     message = 'Mop failed! Please try again later.';
     console.error(err);


### PR DESCRIPTION
## 💸 TL;DR

Added the ability to remove & lock all comments of a post by introducing the `handleNukePost` function.

`handleNukePost` allows a moderator to lock or remove all comments in a post. It fetches a post using the provided post ID, checks if the current user has the necessary mod permissions, and then proceeds to lock or remove all comments in the post based on the provided properties. If the `skipDistinguished` property is true, distinguished comments are skipped. The function logs any failed attempts to lock or remove comments and returns a success message along with the number of comments handled.

Also added a separate form - `nukePostForm` in main.ts for this purpose.

Created this PR after discussing with @pl00h on Discord, the old PR #5 was closed due to changes in the repository structure.

## ✅ Checks
<!-- Make sure your pr passes the CI checks and do check the following fields as needed - -->
- [x] CI tests (if present) are passing
- [x] Adheres to code style for repo
- [x] Contributor License Agreement (CLA) completed if not a Reddit employee
