### PR TITLE
fix Hard-coded credentials

### DIFF
--- a/packages/cli/src/util/auth.ts
+++ b/packages/cli/src/util/auth.ts
@@ -8,10 +8,10 @@ import { DOT_DEVVIT_DIR_FILENAME, REDDIT_DOT_COM } from '../lib/config.js';
 import { DEVVIT_PORTAL_URL } from './config.js';
 
 const PORT = 65010; // Has to match exactly to our oauth app settings
-const CLIENT_ID = 'Bep8X2RRjuoyuxkKsKxFuQ';
+const CLIENT_ID = 'private_secret_id';
 const TOKEN_DURATION = 'permanent';
 const API_V1_URL = `${REDDIT_DOT_COM}/api/v1`;
-const COPY_PASTE_CLIENT_ID = 'TWTsqXa53CexlrYGBWaesQ';
+const COPY_PASTE_CLIENT_ID = 'private_secret_id';
 const COPY_PASTE_REDIRECT_URI = `${DEVVIT_PORTAL_URL}/cli-login`;
 
 const DEVVIT_OAUTH_CLIENT_HEADERS = {


### PR DESCRIPTION
Including unencrypted hard-coded authentication credentials in source code is dangerous because the credentials may be easily discovered, the code may be open source, or it may be leaked or accidentally revealed, making the credentials visible to an attacker. This, in turn, might enable them to gain unauthorized access, or to obtain privileged information.

[CWE-259](https://cwe.mitre.org/data/definitions/259.html).
[CWE-321](https://cwe.mitre.org/data/definitions/321.html).
[CWE-798](https://cwe.mitre.org/data/definitions/798.html).

## ✅ Checks
<!-- Make sure your pr passes the CI checks and do check the following fields as needed - -->
- [ ] CI tests (if present) are passing
- [ ] Adheres to code style for repo
- [ ] Contributor License Agreement (CLA) completed if not a Reddit employee
