### PR TITLE
Remove "stripInternal" flag from @devvit/public-api

### DIFF
--- a/packages/public-api/tsconfig.json
+++ b/packages/public-api/tsconfig.json
@@ -3,7 +3,6 @@
     "outDir": "./dist",
     "rootDir": "./src",
     "exactOptionalPropertyTypes": false,
-    "stripInternal": true,
   },
   "exclude": ["node_modules"],
   "extends": "@devvit/tsconfig/base.json",


### PR DESCRIPTION
Stripping internal functions from the public-api simply makes lives harder for those of us that need access to information that is already present in @devvit/protos, but is otherwise just discarded by the @devvit/public-api.

This doesn't affect the functions themselves still being marked as internal by JSDoc, which is hopefully enough to deter usage by those that don't need them.

<!-- If this pull request closes an issue, please mention the issue number below -->
Closes #208

## 💸 TL;DR
This leaves the type definitions for internal functions present after building the project.

## 🧪 Testing Steps / Validation
This only affects the `*.d.ts` type definition files in the built package, as such it should not affect testable functionality.

## ✅ Checks
<!-- Make sure your pr passes the CI checks and do check the following fields as needed - -->
- [✅] Contributor License Agreement (CLA) completed if not a Reddit employee
