### PR TITLE
feat: Allow explicit definition of new version when uploading app

### DIFF
--- a/packages/cli/src/commands/upload.ts
+++ b/packages/cli/src/commands/upload.ts
@@ -57,6 +57,13 @@ export default class Upload extends DevvitCommand {
         VersionBumpType.Prerelease,
       ],
     })(),
+    version: Flags.custom<DevvitVersion>({
+      description: 'Explicit version number (e.g: 1.0.1)',
+      required: false,
+      multiple: false,
+      parse: async (version) => DevvitVersion.fromString(version),
+      exclusive: ['bump'],
+    })(),
     'employee-update': Flags.boolean({
       aliases: ['employeeUpdate'],
       description:
@@ -174,11 +181,13 @@ export default class Upload extends DevvitCommand {
       );
     }
 
-    // Now, create a new version.
-    const appVersionNumber = await this.#getNextVersionNumber(appInfo, flags.bump);
+    let appVersionNumber = flags.version;
 
+    if (! appVersionNumber) {
+      appVersionNumber = await this.#getNextVersionNumber(appInfo, flags.bump);
+    }
+    
     this.#event.devplatform.app_version_number = appVersionNumber.toString();
-
     ux.action.start('Building');
     const bundles = await this.#bundleActors(username, appVersionNumber.toString());
     ux.action.stop();


### PR DESCRIPTION
## 💸 TL;DR

I want to specify the version of my app when uploading.

## 📜 Details

Not a breaking change.

## 🧪 Testing Steps / Validation

I'm unable to lint, test etc. because it isn't possible to install all of the dependencies, as they depend on access to `snooguts.net`. The change is small enough that it should, hopefully, in theory, work, and be easy enough for someone to test.

## ✅ Checks

- [ ] CI tests (if present) are passing
- [ ] Adheres to code style for repo
- [x] Contributor License Agreement (CLA) completed if not a Reddit employee
