### PR TITLE
fix(cli/publish): Remove leading `@` from inferred version

### DIFF
--- a/packages/cli/src/util/commands/DevvitCommand.ts
+++ b/packages/cli/src/util/commands/DevvitCommand.ts
@@ -200,7 +200,7 @@ export abstract class DevvitCommand extends Command {
     // Otherwise, we need to read appName or app version from the config
     // If the agrument has "@<version>" format
     if (appWithVersion.startsWith('@')) {
-      return { appName: this.project.name, version: appWithVersion };
+      return { appName: this.project.name, version: appWithVersion.slice(1) };
     }
 
     // Otherwise, default to the config and latest.


### PR DESCRIPTION
A version with a leading `@` is not valid. The leading `@` needs to be removed from the version, e.g: `@0.0.0` should become `0.0.0`.