### PR TITLE
Support nested .gitignore in getAppSourceZip

### DIFF
--- a/packages/cli/src/util/getAppSourceZip.ts
+++ b/packages/cli/src/util/getAppSourceZip.ts
@@ -48,6 +48,18 @@ async function addDirectoryToZip(
   ignoredPaths: ignore.Ignore,
   relativePath = ''
 ): Promise<void> {
+  // Check for nested .gitignore
+  const nestedGitignorePath = path.join(dir, '.gitignore');
+  try {
+    const nestedGitignoreContent = await fsp.readFile(nestedGitignorePath, 'utf-8');
+    const nestedGitignorePaths = nestedGitignoreContent
+      .split(/\r?\n/)
+      .map((line) => line.trim());
+    ignoredPaths = ignore().add(ignoredPaths).add(nestedGitignorePaths);
+  } catch {
+    // no-op
+  }
+
   const entries = await fsp.readdir(dir, { withFileTypes: true });
 
   // Process entries in parallel


### PR DESCRIPTION
Added support for nested .gitignore files to improve path ignoring.

Closes #245

## 💸 TL;DR
less stuff in the zip upload

## 📜 Details

It was uploading more than i thought it would, since gitignore stuff is all greyed out.

## 🧪 Testing Steps / Validation
have a child gitignore and see

## ✅ Checks

man just take the change i dont even care this was very minimal

- [ ] CI tests (if present) are passing
- [ ] Adheres to code style for repo
- [ ] Contributor License Agreement (CLA) completed if not a Reddit employee