### PR TITLE
fix: add hSetNX to Redis transaction interface

### DIFF
--- a/packages/public-api/src/apis/redis/RedisClient.ts
+++ b/packages/public-api/src/apis/redis/RedisClient.ts
@@ -354,6 +354,18 @@ export class TxClient implements TxClientLike {
     return this;
   }
 
+  async hsetnx(key: string, field: string, value: string): Promise<TxClientLike> {
+    return this.hSetNX(key, field, value);
+  }
+
+  async hSetNX(key: string, field: string, value: string): Promise<TxClientLike> {
+    await this.#storage.HSetNX(
+      { key, field, value, transactionId: this.#transactionId },
+      this.#metadata
+    );
+    return this;
+  }
+
   async hincrby(key: string, field: string, value: number): Promise<TxClientLike> {
     return this.hIncrBy(key, field, value);
   }

--- a/packages/redis/src/RedisClient.ts
+++ b/packages/redis/src/RedisClient.ts
@@ -314,6 +314,14 @@ export class TxClient implements TxClientLike {
     return this;
   }
 
+  async hSetNX(key: string, field: string, value: string): Promise<TxClientLike> {
+    await this.#plugin.HSetNX(
+      { key, field, value, transactionId: this.#transactionId },
+      this.#metadata
+    );
+    return this;
+  }
+
   async hIncrBy(key: string, field: string, value: number): Promise<TxClientLike> {
     await this.#plugin.HIncrBy(
       { key, field, value, transactionId: this.#transactionId },

--- a/packages/redis/src/types/redis.ts
+++ b/packages/redis/src/types/redis.ts
@@ -573,8 +573,9 @@ export type TxClientLike = {
    *  console.log("Number of fields added: " + numFieldsAdded);
    * }
    * ```
-   */
+  */
   hSet(key: string, fieldValues: { [field: string]: string }): Promise<TxClientLike>;
+  hSetNX(key: string, field: string, value: string): Promise<TxClientLike>;
   /**
    * Returns the value associated with field in the hash stored at key.
    * https://redis.io/commands/hget


### PR DESCRIPTION
## Summary

Adds `hSetNX` to the Redis transaction interface (`TxClientLike`) and both transaction class implementations. The method exists in the non-transaction `RedisClient` but was missing from transactions.

## Why this matters

[#184](https://github.com/reddit/devvit/issues/184) reports that `hSetNX` is unavailable in transactions. The `TxClientLike` type has `hSet`, `hGet`, `hMGet`, `hGetAll`, `hDel`, `hScan`, `hKeys`, `hIncrBy`, and `hLen` but not `hSetNX`. This makes it impossible to use atomic hash-set-if-not-exists operations within Redis transactions.

## Changes

- `packages/redis/src/types/redis.ts` - Added `hSetNX` to `TxClientLike` type
- `packages/redis/src/RedisClient.ts` - Added `hSetNX` to the transaction class, following the same pattern as `hSet` (queue with `transactionId`, return `this`)
- `packages/public-api/src/apis/redis/RedisClient.ts` - Added `hSetNX` and lowercase `hsetnx` alias to the public-api transaction class, matching the alias pattern used by `hset`/`hSet`, `hincrby`/`hIncrBy`, etc.

## Testing

The implementation follows the exact pattern of existing hash methods in the transaction classes. No new test infrastructure was needed - the method signature and behavior matches the non-transaction `hSetNX` (queuing the command with `transactionId` instead of `scope`).

Fixes #184

This contribution was developed with AI assistance (Claude Code + Codex CLI).