### PR TITLE
fix: normalize path separators in devvit create icons asset names

### DIFF
--- a/packages/cli/src/commands/create/icons.ts
+++ b/packages/cli/src/commands/create/icons.ts
@@ -61,7 +61,7 @@ export default class Icons extends DevvitCommand {
     });
     return await Promise.all(
       assets.map(async (asset) => {
-        const name = path.relative(assetsPath, asset);
+        const name = path.relative(assetsPath, asset).replaceAll(path.sep, '/');
         const contents = await fsp.readFile(asset, 'utf-8');
         return { name, contents: stripXmlPreamble(contents) };
       })


### PR DESCRIPTION
## Summary

Normalizes path separators in asset names generated by `devvit create icons` so they use forward slashes on all platforms.

## Why this matters

[#129](https://github.com/reddit/devvit/issues/129) reports that on Windows, `devvit create icons` produces asset names with backslashes (e.g., `subfolder\icon.svg`) because `path.relative()` uses the OS path separator. This results in escape sequences in the generated TypeScript file, breaking asset lookups.

The fix pattern already exists in the same file on line 52 (`.replaceAll(path.sep, '/')`) for the glob path, and in `AssetUploader.ts` lines 607 and 613 for the same purpose. This PR applies the same normalization to the asset name.

## Changes

In `packages/cli/src/commands/create/icons.ts` line 59, added `.replaceAll(path.sep, '/')` to the `path.relative()` call that generates asset names.

## Testing

This matches an established pattern used in 3 other places in the codebase for the same purpose. On non-Windows systems, `path.sep` is already `/` so the call is a no-op.

Fixes #129

This contribution was developed with AI assistance (Claude Code + Codex CLI).