### PR TITLE
docs: remove broken developer documentation link from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 ## Contributing to the Devvit public repo
 
-Reddit has a number of open source projects that developers are invited to contribute to in our GitHub repo. The Developer Platform has several [first-party example apps](https://github.com/reddit/devvit/tree/main/packages/apps) open for contribution. There's also a [public issue board](https://github.com/reddit/devvit/issues) that tracks feature requests and bugs. All feedback is welcome!
+Reddit has a number of open source projects that developers are invited to contribute to in our GitHub repo. The Developer Platform has several [first-party example apps](https://github.com/reddit/devvit/tree/main/packages/apps) and the [developer documentation](https://github.com/reddit/devvit-docs) open for contribution. There's also a [public issue board](https://github.com/reddit/devvit/issues) that tracks feature requests and bugs. All feedback is welcome!
 
 ## Contributor License Agreement
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 ## Contributing to the Devvit public repo
 
-Reddit has a number of open source projects that developers are invited to contribute to in our GitHub repo. The Developer Platform has several [first-party example apps](https://github.com/reddit/devvit/tree/main/packages/apps) and the [developer documentation](https://github.com/reddit/devvit/tree/main/devvit-docs) open for contribution. There's also a [public issue board](https://github.com/reddit/devvit/issues) that tracks feature requests and bugs. All feedback is welcome!
+Reddit has a number of open source projects that developers are invited to contribute to in our GitHub repo. The Developer Platform has several [first-party example apps](https://github.com/reddit/devvit/tree/main/packages/apps) open for contribution. There's also a [public issue board](https://github.com/reddit/devvit/issues) that tracks feature requests and bugs. All feedback is welcome!
 
 ## Contributor License Agreement
 


### PR DESCRIPTION
Summary:
- Removed the broken "developer documentation" link from the README

Why:
- The README currently links to /tree/main/devvit-docs, but that path does not exist in the repository

<!-- If this pull request closes an issue, please mention the issue number below -->
Closes # <!-- Issue # here -->

## 💸 TL;DR
<!-- What's the three sentence summary of purpose of the PR -->

## 📜 Details
[Design Doc](<!-- insert Google Doc link here if applicable -->)

[Jira](<!-- insert Jira link if applicable -->)

<!-- Add additional details required for the PR: breaking changes, screenshots, external dependency changes -->

## 🧪 Testing Steps / Validation
<!-- add details on how this PR has been tested, include reproductions and screenshots where applicable -->

## ✅ Checks
<!-- Make sure your pr passes the CI checks and do check the following fields as needed - -->
- [ ] CI tests (if present) are passing
- [ ] Adheres to code style for repo
- [ ] Contributor License Agreement (CLA) completed if not a Reddit employee
