### PR TITLE
Fix NSFW property on User model and add missing properties

### DIFF
--- a/packages/reddit/src/models/User.ts
+++ b/packages/reddit/src/models/User.ts
@@ -220,6 +220,8 @@ export class User {
   #commentKarma: number;
   #nsfw: boolean;
   #isAdmin: boolean;
+  #isModerator: boolean;
+  #isGold: boolean;
   #modPermissionsBySubreddit: Map<string, ModeratorPermission[]> = new Map();
   // R2 bug: user.url is a permalink path
   #url: string;
@@ -242,8 +244,10 @@ export class User {
     // UserDataByAccountIds returns the ID without the t2_ prefix
     this.#id = T2(isT2(data.id) ? data.id : `t2_${data.id}`);
     this.#username = data.name;
-    this.#nsfw = data.over18 ?? false;
+    this.#nsfw = data.subreddit?.over18 ?? false;
     this.#isAdmin = data.isEmployee ?? false;
+    this.#isModerator = data.IsMod ?? false;
+    this.#isGold = data.isGold ?? false;
 
     const createdAt = new Date(0);
     createdAt.setUTCSeconds(data.createdUtc);
@@ -313,6 +317,16 @@ export class User {
   /** Whether the user is a Reddit employee. */
   get isAdmin(): boolean {
     return this.#isAdmin;
+  }
+
+  /** Whether the user is a moderator of any subreddit. */
+  get isModerator(): boolean {
+    return this.#isModerator;
+  }
+
+  /** Whether the user has Reddit Premium. */
+  get hasRedditPremium(): boolean {
+    return this.#isGold;
   }
 
   /**


### PR DESCRIPTION
<!-- If this pull request closes an issue, please mention the issue number below -->
Closes #193 

## 💸 TL;DR

This pull request addresses two issues on the `User` model:
* NSFW property is returning the wrong value - it currently returns the "I am over 18 and want to see NSFW content" property, rather than the "I am NSFW" property.
* Two underlying properties available on the Data API (isMod and isGold) are not available on the User model. I am now exposing these properly, using the current "Reddit Premium" terminology instead of Reddit Gold.

## 🧪 Testing Steps / Validation
I have tested these locally by modifying files in the node_modules folder. However it is not possible for me to run full CI on this.

For some time I have had my own User model that transforms these values in the same way.

## ✅ Checks
<!-- Make sure your pr passes the CI checks and do check the following fields as needed - -->
- [ ] CI tests (if present) are passing
- [X] Adheres to code style for repo
- [X] Contributor License Agreement (CLA) completed if not a Reddit employee
