### PR TITLE
fix(cli): add locale=en to OAuth authorization URL

### DIFF
--- a/packages/cli/src/lib/auth/NodeFSAuthenticationPlugin.ts
+++ b/packages/cli/src/lib/auth/NodeFSAuthenticationPlugin.ts
@@ -205,6 +205,8 @@ export class NodeFSAuthenticationPlugin {
   async #login(): Promise<StoredToken> {
     const state = crypto.randomBytes(16).toString('hex');
     const authenticationUrl = `${this.#authenticationUrl}?${querystring.stringify({
+      // Force English locale to avoid OAuth redirect issues in non-English locales
+      locale: 'en',
       client_id: this.#authCfg.clientId,
       duration: this.#authCfg.tokenDuration,
       redirect_uri: this.#authCfg.redirectUri,


### PR DESCRIPTION

<!-- If this pull request closes an issue, please mention the issue number below -->
Closes # <!-- Issue # here -->

## 💸 TL;DR
Fixes a login failure in `npx devvit login --copy-paste` for non‑English users.  
Reddit’s OAuth approval form localizes the submit button value, causing `access_denied` when the value is not "Allow".  
Adding `locale=en` to the OAuth URL forces the form to load in English and resolves the issue.

## 📜 Details
Fixing Login Errors Due to Language Settings
npx devvit login --copy-paste

It was found that login fails in both patterns.

Actions Checked:

▶English
- Seamless transition when logging into Reddit
- When logged out of Reddit, OAuth login such as Google is performed.
You can log in with Google and access.

▶Other Languages ​​(Tested Italian, Japanese, French, German, Arabic)
- If logged into Reddit, you are redirected.
- If logged out of Reddit, you are redirected after logging in with a Google account or another OAuth service.

Note: This also does not work in Chrome, Edge, Opera browsers, or in incognito mode.

The cause is a mismatch in the value submitted in the Reddit authentication form. This is because the form value will be a value other than "Allow" depending on the user's display language.
```ts
<button name="authorize" value="Allow" ...>
  <span>
    <span>Accept</span>
  </span>
</button>
```


The server expects a fixed value of "Allow," so when it receives a value translated by the user's language settings, it returns access_denied.

Non-English Settings: Reddit's localization feature translates the `value` attribute, which is the value sent internally.

Solution: Correct Form Value with `locale=en`

To avoid this form validation error, `locale=en` was added to the beginning of the URL parameters.


```terminal
PS C:\devvit\packages\cli> $env:OCLIF_TS_NODE=1; node ./bin/devvit.js login

Press enter to open Reddit to complete authentication:

// code add locale=en
https://www.reddit.com/api/v1/authorize?locale=en&client_id=Bep8X2RRjuoyuxkKsKxFuQ&duration=permanent&redirect_uri=http%3A%2F%2Flocalhost%3A65010%2Fauthorize_callback&response_type=code&scope=%2A&devvit_cli=true&state=fd597e3d853e4ce762e3805f9b800686

redirect url
http://localhost:65010/authorize_callback?state=fd597e3d853e4ce762e3805f9b800686&code=hQmYEDyC3FKK5xjCFZ5GOl0FeM_7LA#_
````

Note: If using a language other than English, manually changing the "available" value in the form to "Allow" before authentication will allow you to log in.

1. Forcing the entire page to load in English ensures that the form value is "Allow," guaranteeing successful authentication.

2. This eliminates the need for users to change their browser settings (a temporary solution), allowing them to complete login using only standard CLI operations.

3. Protection and Visibility of * (%2A)
Reddit OAuth specifications require the wildcard * to be correctly maintained as %2A. Specifying `locale=en` prevents encoding issues caused by redirects (such as reverting back to *).

User Transparency: `locale=en` is placed near the beginning of the URL. This makes it easier for users to intuitively understand the intention that "security authentication is currently being performed in English" simply by looking at the URL.

This is not a fundamental solution. At the very least, a mechanism should be in place to prevent the value of the form's name field from being translated.

### 🚨 Problem Summary
Users with non‑English browser language settings (Japanese, German, Italian, French, Arabic, etc.) experience OAuth login failures when running:

- `npx devvit login`
- `npx devvit login --copy-paste`

The Reddit authorization form localizes the submit button value:

However, the server expects the fixed English value `"Allow"`.  
When a localized value is submitted, the server returns `access_denied`.

### 🔧 Technical Root Cause
The OAuth approval form is localized based on the user's browser language.  
The backend validation does **not** accept localized values and only accepts `"Allow"`.  
This mismatch causes the login flow to fail for international users.

### 💡 Solution
Add `locale=en` to the OAuth authorization URL to force the form to load in English.

This ensures:
1. The submit value is always `"Allow"`  
2. International users can authenticate without changing browser settings  
3. Wildcard characters (`*`) remain correctly encoded through redirects  
4. The parameter is placed at the beginning of the URL for clarity and transparency  

### 📊 Impact
- **English users**: No change  
- **Non‑English users**: Login now succeeds without manual intervention  
- **Browsers tested**: Chrome, Edge, Opera, Incognito  
- **Languages tested**: Japanese, German, Italian, French, Arabic  

## 🧪 Testing Steps / Validation
- Verified that manually changing the localized submit value to `"Allow"` makes login succeed  
- After adding `locale=en`, login succeeds in all tested non‑English environments  

This indicates that the display language is influencing the process.

- Confirmed both:
  - `npx devvit login` (localhost mode)
  - `npx devvit login --copy-paste`
  work correctly  

## 🔗 Related Issue
Fixes OAuth login failures caused by localization of the approval form.

## ✅ Checks
- [ ] CI tests (if present) are passing
- [ ] Adheres to code style for repo
- [ ] Contributor License Agreement (CLA) completed if not a Reddit employee
