### PR TITLE
Fix ModNote.fromProto to map modActionData to modAction

### DIFF
--- a/packages/public-api/src/apis/reddit/models/ModNote.ts
+++ b/packages/public-api/src/apis/reddit/models/ModNote.ts
@@ -28,6 +28,12 @@ export type ModNoteType =
   | 'MOD_ACTION'
   | 'ALL';
 
+/**
+ * Action metadata from a mod note's `modActionData`. Kept separate from
+ * {@link ModAction} to reduce field duplication — mod notes and moderation
+ * log entries are distinct use cases, and {@link ModNote} already provides
+ * moderator, subreddit, and timestamp context.
+ */
 export type ModNoteAction = {
   action: ModActionType;
   redditId?: T1ID | T2ID | T3ID | undefined;

--- a/packages/public-api/src/apis/reddit/models/ModNote.ts
+++ b/packages/public-api/src/apis/reddit/models/ModNote.ts
@@ -14,7 +14,7 @@ import type { T1ID, T2ID, T3ID, T5ID } from '../../../types/tid.js';
 import { asT2ID, asT5ID, asTID } from '../../../types/tid.js';
 import type { ListingFetchOptions, ListingFetchResponse } from './Listing.js';
 import { Listing } from './Listing.js';
-import type { ModAction, ModActionType } from './ModAction.js';
+import type { ModActionType } from './ModAction.js';
 
 export type ModNoteType =
   | 'NOTE'
@@ -28,6 +28,15 @@ export type ModNoteType =
   | 'MOD_ACTION'
   | 'ALL';
 
+export type ModNoteAction = {
+  action: ModActionType;
+  redditId?: T1ID | T2ID | T3ID | undefined;
+  /** For `banuser` actions, the number of days in a format like `"1 days"` */
+  details?: string | undefined;
+  /** For `banuser` actions, the reasoning for the ban */
+  description?: string | undefined;
+};
+
 export type UserNoteLabel =
   | 'BOT_BAN'
   | 'PERMA_BAN'
@@ -39,9 +48,9 @@ export type UserNoteLabel =
   | 'HELPFUL_USER';
 
 export type UserNote = {
-  note?: string;
-  redditId?: T1ID | T3ID | T5ID;
-  label?: UserNoteLabel;
+  note?: string | undefined;
+  redditId?: T1ID | T3ID | T5ID | undefined;
+  label?: UserNoteLabel | undefined;
 };
 
 export interface ModNote {
@@ -60,8 +69,8 @@ export interface ModNote {
   };
   type: ModNoteType;
   createdAt: Date;
-  userNote?: UserNote;
-  modAction?: ModAction;
+  userNote?: UserNote | undefined;
+  modAction?: ModNoteAction;
 }
 
 export type GetModNotesOptions = Prettify<
@@ -102,7 +111,7 @@ export class ModNote {
     assertNonNull(protoModNote.modActionData, 'Mod note modAction is null or undefined');
 
     const createdAt = new Date(protoModNote.createdAt! * 1000); // convert to ms
-    const modAction = this.#modActionDataToModAction(protoModNote, createdAt);
+    const modActionData = protoModNote.modActionData;
 
     return {
       id: protoModNote.id,
@@ -127,30 +136,16 @@ export class ModNote {
         label: protoModNote.userNoteData?.label as UserNoteLabel,
       },
       type: protoModNote.type as ModNoteType,
-      modAction,
-    };
-  }
-
-  static #modActionDataToModAction(
-    protoModNote: ModNoteObject,
-    createdAt: Date
-  ): ModAction | undefined {
-    const modActionData = protoModNote.modActionData;
-    if (!modActionData?.action) {
-      return undefined;
-    }
-
-    return {
-      id: protoModNote.id!,
-      type: modActionData.action as ModActionType,
-      moderatorName: protoModNote.operator ?? '',
-      moderatorId: asT2ID(protoModNote.operatorId ?? ''),
-      createdAt,
-      subredditName: protoModNote.subreddit ?? '',
-      subredditId: asT5ID(protoModNote.subredditId ?? ''),
-      description: modActionData.description,
-      details: modActionData.details,
-      target: modActionData.redditId ? { id: modActionData.redditId } : undefined,
+      modAction: modActionData?.action
+        ? {
+            action: modActionData.action as ModActionType,
+            redditId: modActionData.redditId
+              ? asTID<T1ID | T2ID | T3ID>(modActionData.redditId)
+              : undefined,
+            details: modActionData.details,
+            description: modActionData.description,
+          }
+        : undefined,
     };
   }
 

--- a/packages/public-api/src/apis/reddit/models/ModNote.ts
+++ b/packages/public-api/src/apis/reddit/models/ModNote.ts
@@ -54,9 +54,9 @@ export type UserNoteLabel =
   | 'HELPFUL_USER';
 
 export type UserNote = {
-  note?: string | undefined;
-  redditId?: T1ID | T3ID | T5ID | undefined;
-  label?: UserNoteLabel | undefined;
+  note?: string;
+  redditId?: T1ID | T3ID | T5ID;
+  label?: UserNoteLabel;
 };
 
 export interface ModNote {
@@ -75,7 +75,7 @@ export interface ModNote {
   };
   type: ModNoteType;
   createdAt: Date;
-  userNote?: UserNote | undefined;
+  userNote?: UserNote;
   modAction?: ModNoteAction;
 }
 
@@ -116,7 +116,6 @@ export class ModNote {
     assertNonNull(protoModNote.userNoteData, 'Mod note userNote is null or undefined');
     assertNonNull(protoModNote.modActionData, 'Mod note modAction is null or undefined');
 
-    const createdAt = new Date(protoModNote.createdAt! * 1000); // convert to ms
     const modActionData = protoModNote.modActionData;
 
     return {
@@ -133,7 +132,7 @@ export class ModNote {
         id: asT2ID(protoModNote.operatorId ?? ''),
         name: protoModNote.operator,
       },
-      createdAt,
+      createdAt: new Date(protoModNote.createdAt! * 1000), // convert to ms
       userNote: {
         note: protoModNote.userNoteData?.note,
         redditId: protoModNote.userNoteData?.redditId

--- a/packages/public-api/src/apis/reddit/models/ModNote.ts
+++ b/packages/public-api/src/apis/reddit/models/ModNote.ts
@@ -14,7 +14,7 @@ import type { T1ID, T2ID, T3ID, T5ID } from '../../../types/tid.js';
 import { asT2ID, asT5ID, asTID } from '../../../types/tid.js';
 import type { ListingFetchOptions, ListingFetchResponse } from './Listing.js';
 import { Listing } from './Listing.js';
-import type { ModAction } from './ModAction.js';
+import type { ModAction, ModActionType } from './ModAction.js';
 
 export type ModNoteType =
   | 'NOTE'
@@ -101,6 +101,9 @@ export class ModNote {
     assertNonNull(protoModNote.userNoteData, 'Mod note userNote is null or undefined');
     assertNonNull(protoModNote.modActionData, 'Mod note modAction is null or undefined');
 
+    const createdAt = new Date(protoModNote.createdAt! * 1000); // convert to ms
+    const modAction = this.#modActionDataToModAction(protoModNote, createdAt);
+
     return {
       id: protoModNote.id,
       user: {
@@ -115,7 +118,7 @@ export class ModNote {
         id: asT2ID(protoModNote.operatorId ?? ''),
         name: protoModNote.operator,
       },
-      createdAt: new Date(protoModNote.createdAt! * 1000), // convert to ms
+      createdAt,
       userNote: {
         note: protoModNote.userNoteData?.note,
         redditId: protoModNote.userNoteData?.redditId
@@ -124,6 +127,30 @@ export class ModNote {
         label: protoModNote.userNoteData?.label as UserNoteLabel,
       },
       type: protoModNote.type as ModNoteType,
+      modAction,
+    };
+  }
+
+  static #modActionDataToModAction(
+    protoModNote: ModNoteObject,
+    createdAt: Date
+  ): ModAction | undefined {
+    const modActionData = protoModNote.modActionData;
+    if (!modActionData?.action) {
+      return undefined;
+    }
+
+    return {
+      id: protoModNote.id!,
+      type: modActionData.action as ModActionType,
+      moderatorName: protoModNote.operator ?? '',
+      moderatorId: asT2ID(protoModNote.operatorId ?? ''),
+      createdAt,
+      subredditName: protoModNote.subreddit ?? '',
+      subredditId: asT5ID(protoModNote.subredditId ?? ''),
+      description: modActionData.description,
+      details: modActionData.details,
+      target: modActionData.redditId ? { id: modActionData.redditId } : undefined,
     };
   }
 

--- a/packages/public-api/src/apis/reddit/tests/modnote.api.test.ts
+++ b/packages/public-api/src/apis/reddit/tests/modnote.api.test.ts
@@ -13,6 +13,55 @@ describe('ModNote API', () => {
   });
 
   describe('RedditAPIClient:ModNote', () => {
+    test('getModNotes() maps modActionData to modAction', async () => {
+      const spyPlugin = vi.spyOn(Devvit.redditAPIPlugins.ModNote, 'GetNotes');
+      spyPlugin.mockImplementationOnce(async () => ({
+        modNotes: [
+          {
+            id: 'ModNote_test',
+            createdAt: 1_709_251_200,
+            type: 'MOD_ACTION',
+            subreddit: 'testsub',
+            subredditId: 't5_test',
+            user: 'test-user',
+            userId: 't2_user',
+            operator: 'test-mod',
+            operatorId: 't2_mod',
+            userNoteData: {},
+            modActionData: {
+              action: 'banuser',
+              details: '14 day ban',
+              description: 'Second ban',
+            },
+          },
+        ],
+        hasNextPage: false,
+      }));
+
+      const notes = await api.reddit
+        .getModNotes({
+          subreddit: 'testsub',
+          user: 'test-user',
+          filter: 'MOD_ACTION',
+          limit: 100,
+        })
+        .all();
+
+      expect(notes).toHaveLength(1);
+      expect(notes[0]?.modAction).toEqual({
+        id: 'ModNote_test',
+        type: 'banuser',
+        moderatorName: 'test-mod',
+        moderatorId: 't2_mod',
+        createdAt: new Date('2024-03-01T00:00:00Z'),
+        subredditName: 'testsub',
+        subredditId: 't5_test',
+        description: 'Second ban',
+        details: '14 day ban',
+        target: undefined,
+      });
+    });
+
     test('addRemovalNote()', async () => {
       const spyPlugin = vi.spyOn(Devvit.redditAPIPlugins.ModNote, 'PostRemovalNote');
       spyPlugin.mockImplementationOnce(async () => ({}));

--- a/packages/public-api/src/apis/reddit/tests/modnote.api.test.ts
+++ b/packages/public-api/src/apis/reddit/tests/modnote.api.test.ts
@@ -32,6 +32,7 @@ describe('ModNote API', () => {
               action: 'banuser',
               details: '14 day ban',
               description: 'Second ban',
+              redditId: 't2_target',
             },
           },
         ],
@@ -49,16 +50,10 @@ describe('ModNote API', () => {
 
       expect(notes).toHaveLength(1);
       expect(notes[0]?.modAction).toEqual({
-        id: 'ModNote_test',
-        type: 'banuser',
-        moderatorName: 'test-mod',
-        moderatorId: 't2_mod',
-        createdAt: new Date('2024-03-01T00:00:00Z'),
-        subredditName: 'testsub',
-        subredditId: 't5_test',
+        action: 'banuser',
         description: 'Second ban',
         details: '14 day ban',
-        target: undefined,
+        redditId: 't2_target',
       });
     });
 

--- a/packages/reddit/src/models/ModNote.ts
+++ b/packages/reddit/src/models/ModNote.ts
@@ -14,7 +14,7 @@ import { asTid, T1, T2, T3, T5 } from '@devvit/shared-types/tid.js';
 import { getRedditApiPlugins } from '../plugin.js';
 import type { ListingFetchOptions, ListingFetchResponse } from './Listing.js';
 import { Listing } from './Listing.js';
-import type { ModAction, ModActionType } from './ModAction.js';
+import type { ModActionType } from './ModAction.js';
 
 export type ModNoteType =
   | 'NOTE'
@@ -27,6 +27,15 @@ export type ModNoteType =
   | 'CONTENT_CHANGE'
   | 'MOD_ACTION'
   | 'ALL';
+
+export type ModNoteAction = {
+  action: ModActionType;
+  redditId?: T1 | T2 | T3 | undefined;
+  /** For `banuser` actions, the number of days in a format like `"1 days"` */
+  details?: string | undefined;
+  /** For `banuser` actions, the reasoning for the ban */
+  description?: string | undefined;
+};
 
 export type UserNoteLabel =
   | 'BOT_BAN'
@@ -61,7 +70,7 @@ export interface ModNote {
   type: ModNoteType;
   createdAt: Date;
   userNote?: UserNote | undefined;
-  modAction?: ModAction;
+  modAction?: ModNoteAction;
 }
 
 export type GetModNotesOptions = Prettify<
@@ -102,7 +111,7 @@ export class ModNote {
     assertNonNull(protoModNote.modActionData, 'Mod note modAction is null or undefined');
 
     const createdAt = new Date(protoModNote.createdAt! * 1000); // convert to ms
-    const modAction = this.#modActionDataToModAction(protoModNote, createdAt);
+    const modActionData = protoModNote.modActionData;
 
     return {
       id: protoModNote.id,
@@ -127,30 +136,16 @@ export class ModNote {
         label: protoModNote.userNoteData?.label as UserNoteLabel,
       },
       type: protoModNote.type as ModNoteType,
-      modAction,
-    };
-  }
-
-  static #modActionDataToModAction(
-    protoModNote: ModNoteObject,
-    createdAt: Date
-  ): ModAction | undefined {
-    const modActionData = protoModNote.modActionData;
-    if (!modActionData?.action) {
-      return undefined;
-    }
-
-    return {
-      id: protoModNote.id!,
-      type: modActionData.action as ModActionType,
-      moderatorName: protoModNote.operator ?? '',
-      moderatorId: T2(protoModNote.operatorId ?? ''),
-      createdAt,
-      subredditName: protoModNote.subreddit ?? '',
-      subredditId: T5(protoModNote.subredditId ?? ''),
-      description: modActionData.description,
-      details: modActionData.details,
-      target: modActionData.redditId ? { id: modActionData.redditId } : undefined,
+      modAction: modActionData?.action
+        ? {
+            action: modActionData.action as ModActionType,
+            redditId: modActionData.redditId
+              ? asTid<T1 | T2 | T3>(modActionData.redditId)
+              : undefined,
+            details: modActionData.details,
+            description: modActionData.description,
+          }
+        : undefined,
     };
   }
 

--- a/packages/reddit/src/models/ModNote.ts
+++ b/packages/reddit/src/models/ModNote.ts
@@ -28,6 +28,12 @@ export type ModNoteType =
   | 'MOD_ACTION'
   | 'ALL';
 
+/**
+ * Action metadata from a mod note's `modActionData`. Kept separate from
+ * {@link ModAction} to reduce field duplication — mod notes and moderation
+ * log entries are distinct use cases, and {@link ModNote} already provides
+ * moderator, subreddit, and timestamp context.
+ */
 export type ModNoteAction = {
   action: ModActionType;
   redditId?: T1 | T2 | T3 | undefined;

--- a/packages/reddit/src/models/ModNote.ts
+++ b/packages/reddit/src/models/ModNote.ts
@@ -75,7 +75,7 @@ export interface ModNote {
   };
   type: ModNoteType;
   createdAt: Date;
-  userNote?: UserNote | undefined;
+  userNote?: UserNote;
   modAction?: ModNoteAction;
 }
 
@@ -116,7 +116,6 @@ export class ModNote {
     assertNonNull(protoModNote.userNoteData, 'Mod note userNote is null or undefined');
     assertNonNull(protoModNote.modActionData, 'Mod note modAction is null or undefined');
 
-    const createdAt = new Date(protoModNote.createdAt! * 1000); // convert to ms
     const modActionData = protoModNote.modActionData;
 
     return {
@@ -133,7 +132,7 @@ export class ModNote {
         id: T2(protoModNote.operatorId ?? ''),
         name: protoModNote.operator,
       },
-      createdAt,
+      createdAt: new Date(protoModNote.createdAt! * 1000), // convert to ms
       userNote: {
         note: protoModNote.userNoteData?.note,
         redditId: protoModNote.userNoteData?.redditId

--- a/packages/reddit/src/models/ModNote.ts
+++ b/packages/reddit/src/models/ModNote.ts
@@ -14,7 +14,7 @@ import { asTid, T1, T2, T3, T5 } from '@devvit/shared-types/tid.js';
 import { getRedditApiPlugins } from '../plugin.js';
 import type { ListingFetchOptions, ListingFetchResponse } from './Listing.js';
 import { Listing } from './Listing.js';
-import type { ModAction } from './ModAction.js';
+import type { ModAction, ModActionType } from './ModAction.js';
 
 export type ModNoteType =
   | 'NOTE'
@@ -101,6 +101,9 @@ export class ModNote {
     assertNonNull(protoModNote.userNoteData, 'Mod note userNote is null or undefined');
     assertNonNull(protoModNote.modActionData, 'Mod note modAction is null or undefined');
 
+    const createdAt = new Date(protoModNote.createdAt! * 1000); // convert to ms
+    const modAction = this.#modActionDataToModAction(protoModNote, createdAt);
+
     return {
       id: protoModNote.id,
       user: {
@@ -115,7 +118,7 @@ export class ModNote {
         id: T2(protoModNote.operatorId ?? ''),
         name: protoModNote.operator,
       },
-      createdAt: new Date(protoModNote.createdAt! * 1000), // convert to ms
+      createdAt,
       userNote: {
         note: protoModNote.userNoteData?.note,
         redditId: protoModNote.userNoteData?.redditId
@@ -124,6 +127,30 @@ export class ModNote {
         label: protoModNote.userNoteData?.label as UserNoteLabel,
       },
       type: protoModNote.type as ModNoteType,
+      modAction,
+    };
+  }
+
+  static #modActionDataToModAction(
+    protoModNote: ModNoteObject,
+    createdAt: Date
+  ): ModAction | undefined {
+    const modActionData = protoModNote.modActionData;
+    if (!modActionData?.action) {
+      return undefined;
+    }
+
+    return {
+      id: protoModNote.id!,
+      type: modActionData.action as ModActionType,
+      moderatorName: protoModNote.operator ?? '',
+      moderatorId: T2(protoModNote.operatorId ?? ''),
+      createdAt,
+      subredditName: protoModNote.subreddit ?? '',
+      subredditId: T5(protoModNote.subredditId ?? ''),
+      description: modActionData.description,
+      details: modActionData.details,
+      target: modActionData.redditId ? { id: modActionData.redditId } : undefined,
     };
   }
 

--- a/packages/reddit/src/tests/modnote.api.test.ts
+++ b/packages/reddit/src/tests/modnote.api.test.ts
@@ -17,6 +17,57 @@ describe('ModNote API', () => {
   const redditAPI = new RedditClient();
 
   describe('RedditClient:ModNote', () => {
+    test('getModNotes() maps modActionData to modAction', async () => {
+      const spyPlugin = redditApiPlugins.ModNote.GetNotes;
+      spyPlugin.mockImplementationOnce(async () => ({
+        modNotes: [
+          {
+            id: 'ModNote_test',
+            createdAt: 1_709_251_200,
+            type: 'MOD_ACTION',
+            subreddit: 'testsub',
+            subredditId: 't5_test',
+            user: 'test-user',
+            userId: 't2_user',
+            operator: 'test-mod',
+            operatorId: 't2_mod',
+            userNoteData: {},
+            modActionData: {
+              action: 'banuser',
+              details: '14 day ban',
+              description: 'Second ban',
+            },
+          },
+        ],
+        hasNextPage: false,
+      }));
+
+      await runWithTestContext(async () => {
+        const notes = await redditAPI
+          .getModNotes({
+            subreddit: 'testsub',
+            user: 'test-user',
+            filter: 'MOD_ACTION',
+            limit: 100,
+          })
+          .all();
+
+        expect(notes).toHaveLength(1);
+        expect(notes[0]?.modAction).toEqual({
+          id: 'ModNote_test',
+          type: 'banuser',
+          moderatorName: 'test-mod',
+          moderatorId: 't2_mod',
+          createdAt: new Date('2024-03-01T00:00:00Z'),
+          subredditName: 'testsub',
+          subredditId: 't5_test',
+          description: 'Second ban',
+          details: '14 day ban',
+          target: undefined,
+        });
+      });
+    });
+
     test('addRemovalNote()', async () => {
       const spyPlugin = redditApiPlugins.ModNote.PostRemovalNote;
       spyPlugin.mockImplementationOnce(async () => ({}));

--- a/packages/reddit/src/tests/modnote.api.test.ts
+++ b/packages/reddit/src/tests/modnote.api.test.ts
@@ -36,6 +36,7 @@ describe('ModNote API', () => {
               action: 'banuser',
               details: '14 day ban',
               description: 'Second ban',
+              redditId: 't2_target',
             },
           },
         ],
@@ -54,16 +55,10 @@ describe('ModNote API', () => {
 
         expect(notes).toHaveLength(1);
         expect(notes[0]?.modAction).toEqual({
-          id: 'ModNote_test',
-          type: 'banuser',
-          moderatorName: 'test-mod',
-          moderatorId: 't2_mod',
-          createdAt: new Date('2024-03-01T00:00:00Z'),
-          subredditName: 'testsub',
-          subredditId: 't5_test',
+          action: 'banuser',
           description: 'Second ban',
           details: '14 day ban',
-          target: undefined,
+          redditId: 't2_target',
         });
       });
     });


### PR DESCRIPTION
## Motivation

While writing a moderation app that auto-applies escalating bans, I realized that the modAction wasn't actually being converted from the proto.

In my app, I worked around this by directly calling `getDevvitConfig().use(ModNoteDefinition);`, which is a bit of a hack, so I wanted to resolve this more permanently with this upstream PR.

## Changes

- Introduce `ModNoteAction` — a focused type with `action`, `redditId`, `details`, and `description` — instead of reusing the full `ModAction` type
- Map `modActionData` inline in `ModNote.#fromProto` for both `@devvit/reddit` and `@devvit/public-api`
- Parse `redditId` with typed ID helpers (`asTID` / `asTid`) for `T1`/`T2`/`T3` fullnames
- Document `details` and `description` for `banuser` actions (duration like `"1 days"`, ban reasoning)
- Update mod note API tests to assert the slimmer `modAction` shape

## Testing

**I couldn't really test this unfortunately since the root README.md instructions failed at the point I tried to `yarn` to install, since there were many Reddit-internal packages whose installs didn't work even after I disabled artifactory. I did do a thorough self-review of the PR though and its logic looks pretty simple**

- [ ] `yarn workspace @devvit/reddit test:unit` — `getModNotes() maps modActionData to modAction` test
- [ ] `yarn workspace @devvit/public-api test:unit` — same test in public-api package
- [ ] Manual: call `reddit.getModNotes({ subreddit, user, filter: 'MOD_ACTION' })` and verify ban notes include `modAction.details` and `modAction.description`