### PR TITLE
Prototype CLI authorization for Devvit app maintainers

### DIFF
--- a/packages/cli/src/commands/playtest.ts
+++ b/packages/cli/src/commands/playtest.ts
@@ -50,6 +50,10 @@ import { toLowerCaseArgParser } from '../util/commands/DevvitCommand.js';
 import { DevvitCommand } from '../util/commands/DevvitCommand.js';
 import { getSubredditNameWithoutPrefix } from '../util/common-actions/getSubredditNameWithoutPrefix.js';
 import { installOnSubreddit } from '../util/common-actions/installOnSubreddit.js';
+import {
+  canWriteAppVersion,
+  getAppAuthorizationRole,
+} from '../util/authorization/appAuthorization.js';
 import { waitUntilVersionBuildComplete } from '../util/common-actions/waitUntilVersionBuildComplete.js';
 import { getAppBySlug } from '../util/getAppBySlug.js';
 import { killProcessTree, killProcessTreeSync } from '../util/kill-process-tree.js';
@@ -433,10 +437,13 @@ export default class Playtest extends DevvitCommand {
     }
     this.project.app.defaultPlaytestSubredditId = this.#appInfo.app.defaultPlaytestSubredditId;
 
-    const isOwner = this.#appInfo?.app?.owner?.id === userInfo.id;
+    const appAuthorizationRole = getAppAuthorizationRole(this.#appInfo, {
+      id: userInfo.id,
+      displayName: userInfo.username,
+    });
     await this.#checkIfUserAllowedToPlaytestThisApp(
       this.project.name,
-      isOwner,
+      canWriteAppVersion(appAuthorizationRole),
       token,
       flags['employee-update']
     );
@@ -869,11 +876,11 @@ export default class Playtest extends DevvitCommand {
 
   async #checkIfUserAllowedToPlaytestThisApp(
     appName: string,
-    isOwner: boolean,
+    isAuthorizedToWriteApp: boolean,
     token: StoredToken,
     employeeUpdateFlag: boolean
   ): Promise<void> {
-    if (isOwner) {
+    if (isAuthorizedToWriteApp) {
       return;
     }
 
@@ -888,7 +895,9 @@ export default class Playtest extends DevvitCommand {
       // Check if the app name is available, implying this is a first run
       const appExists = await checkAppNameAvailability(this.#appClient, appName);
       if (appExists.exists) {
-        this.error(`That app already exists, and you can't playtest someone else's app!`);
+        this.error(
+          `That app already exists, and you are not its owner or a designated maintainer.`
+        );
       }
 
       // App doesn't exist - tell the user to run `devvit upload` first

--- a/packages/cli/src/commands/publish.ts
+++ b/packages/cli/src/commands/publish.ts
@@ -55,6 +55,11 @@ import { DevvitCommand } from '../util/commands/DevvitCommand.js';
 import { installOnSubreddit } from '../util/common-actions/installOnSubreddit.js';
 import { waitUntilVersionBuildComplete } from '../util/common-actions/waitUntilVersionBuildComplete.js';
 import { DEVVIT_PORTAL_URL } from '../util/config.js';
+import {
+  canWriteAppVersion,
+  getAppAuthorizationErrorMessage,
+  getAppAuthorizationRole,
+} from '../util/authorization/appAuthorization.js';
 import { getAppBySlug } from '../util/getAppBySlug.js';
 import { getAppSourceZip } from '../util/getAppSourceZip.js';
 import { readLine } from '../util/input-util.js';
@@ -205,8 +210,8 @@ export default class Publish extends DevvitCommand {
 
     const shouldCreatePlaytestSubreddit = !this.project.getSubreddit('Dev');
 
-    const isOwner = appInfo.app.owner?.displayName === username;
-    if (!isOwner) {
+    const appAuthorizationRole = getAppAuthorizationRole(appInfo, username);
+    if (!canWriteAppVersion(appAuthorizationRole)) {
       if (flags['employee-update']) {
         const isEmployee = await isCurrentUserEmployee(token);
         if (!isEmployee) {
@@ -214,9 +219,7 @@ export default class Publish extends DevvitCommand {
         }
         this.warn(`Overriding ownership check because you're an employee and told me to!`);
       } else {
-        this.error(
-          `You are not the owner of the app "${this.project.name}". Please check that you are logged in as the correct user (${appInfo.app.owner?.displayName ?? '<unknown>'}).`
-        );
+        this.error(getAppAuthorizationErrorMessage(appInfo, this.project.name, 'publish'));
       }
     }
 

--- a/packages/cli/src/commands/publish.ts
+++ b/packages/cli/src/commands/publish.ts
@@ -183,7 +183,8 @@ export default class Publish extends DevvitCommand {
     const token = await getAccessTokenAndLoginIfNeeded(
       flags['copy-paste'] ? 'CopyPaste' : 'LocalSocket'
     );
-    const username = await this.getUserDisplayName(token);
+    const userInfo = await this.getUserInfo(token);
+    const username = userInfo.username;
 
     await this.checkDeveloperAccount();
 
@@ -210,7 +211,10 @@ export default class Publish extends DevvitCommand {
 
     const shouldCreatePlaytestSubreddit = !this.project.getSubreddit('Dev');
 
-    const appAuthorizationRole = getAppAuthorizationRole(appInfo, username);
+    const appAuthorizationRole = getAppAuthorizationRole(appInfo, {
+      id: userInfo.id,
+      displayName: username,
+    });
     if (!canWriteAppVersion(appAuthorizationRole)) {
       if (flags['employee-update']) {
         const isEmployee = await isCurrentUserEmployee(token);

--- a/packages/cli/src/commands/upload.ts
+++ b/packages/cli/src/commands/upload.ts
@@ -53,7 +53,7 @@ import {
 } from './init.js';
 
 export default class Upload extends DevvitCommand {
-  static override description = `Upload the app to the App Directory. Uploaded apps are only visible to you (the app owner) and can only be installed to a small test subreddit with less than ${MAX_ALLOWED_SUBSCRIBER_COUNT} subscribers`;
+  static override description = `Upload the app to the App Directory. Uploaded apps are visible to the app owner and designated maintainers and can only be installed to a small test subreddit with less than ${MAX_ALLOWED_SUBSCRIBER_COUNT} subscribers`;
 
   static override flags = {
     bump: Flags.custom<VersionBumpType>({
@@ -129,7 +129,8 @@ export default class Upload extends DevvitCommand {
     const token = await getAccessTokenAndLoginIfNeeded(
       flags['copy-paste'] ? 'CopyPaste' : 'LocalSocket'
     );
-    const username = await this.getUserDisplayName(token);
+    const userInfo = await this.getUserInfo(token);
+    const username = userInfo.username;
 
     await this.checkDeveloperAccount();
 
@@ -147,14 +148,19 @@ export default class Upload extends DevvitCommand {
     let shouldCreateNewApp = false;
     let shouldCreatePlaytestSubreddit = !this.project.getSubreddit('Dev');
 
-    const appAuthorizationRole = getAppAuthorizationRole(appInfo, username);
+    const appAuthorizationRole = getAppAuthorizationRole(appInfo, {
+      id: userInfo.id,
+      displayName: username,
+    });
     if (!canWriteAppVersion(appAuthorizationRole)) {
       shouldCreateNewApp = true;
       // Unless...
       if (flags['employee-update'] || flags['just-do-it']) {
         const isEmployee = await isCurrentUserEmployee(token);
         if (!isEmployee) {
-          this.error(`You're not an employee, so you can't playtest someone else's app.`);
+          this.error(
+            `You're not an employee, so you can't upload a version of someone else's app.`
+          );
         }
         // Else, we're an employee, so we can update someone else's app
         this.warn(`Overriding ownership check because you're an employee and told me to!`);

--- a/packages/cli/src/commands/upload.ts
+++ b/packages/cli/src/commands/upload.ts
@@ -38,6 +38,10 @@ import {
 import { DevvitCommand } from '../util/commands/DevvitCommand.js';
 import { installOnSubreddit } from '../util/common-actions/installOnSubreddit.js';
 import { DEVVIT_PORTAL_URL } from '../util/config.js';
+import {
+  canWriteAppVersion,
+  getAppAuthorizationRole,
+} from '../util/authorization/appAuthorization.js';
 import { getAppBySlug } from '../util/getAppBySlug.js';
 import { sendEvent } from '../util/metrics.js';
 import {
@@ -143,8 +147,8 @@ export default class Upload extends DevvitCommand {
     let shouldCreateNewApp = false;
     let shouldCreatePlaytestSubreddit = !this.project.getSubreddit('Dev');
 
-    const isOwner = appInfo?.app?.owner?.displayName === username;
-    if (!isOwner) {
+    const appAuthorizationRole = getAppAuthorizationRole(appInfo, username);
+    if (!canWriteAppVersion(appAuthorizationRole)) {
       shouldCreateNewApp = true;
       // Unless...
       if (flags['employee-update'] || flags['just-do-it']) {

--- a/packages/cli/src/util/authorization/appAuthorization.test.ts
+++ b/packages/cli/src/util/authorization/appAuthorization.test.ts
@@ -1,0 +1,62 @@
+// eslint-disable-next-line no-restricted-imports
+import type { FullAppInfo } from '@devvit/protos/types/devvit/dev_portal/app/app.js';
+import { describe, expect, test } from 'vitest';
+
+import {
+  canWriteAppVersion,
+  getAppAuthorizationErrorMessage,
+  getAppAuthorizationRole,
+} from './appAuthorization.js';
+
+describe('appAuthorization', () => {
+  test('allows the app owner to write app versions', () => {
+    const appInfo = {
+      app: {
+        owner: { displayName: 'OwnerName' },
+      },
+    };
+
+    const role = getAppAuthorizationRole(appInfo as FullAppInfo, 'ownername');
+
+    expect(role).toBe('owner');
+    expect(canWriteAppVersion(role)).toBe(true);
+  });
+
+  test('allows a designated app maintainer to write app versions', () => {
+    const appInfo = {
+      app: {
+        owner: { displayName: 'OwnerName' },
+        maintainers: [{ displayName: 'MaintainerName' }],
+      },
+    };
+
+    const role = getAppAuthorizationRole(appInfo as FullAppInfo, 'maintainername');
+
+    expect(role).toBe('maintainer');
+    expect(canWriteAppVersion(role)).toBe(true);
+  });
+
+  test('does not allow unrelated developers to write app versions', () => {
+    const appInfo = {
+      app: {
+        owner: { displayName: 'OwnerName' },
+        maintainers: [{ displayName: 'MaintainerName' }],
+      },
+    };
+
+    const role = getAppAuthorizationRole(appInfo as FullAppInfo, 'OtherDeveloper');
+
+    expect(role).toBe('unauthorized');
+    expect(canWriteAppVersion(role)).toBe(false);
+  });
+
+  test('uses a maintainer-aware error message', () => {
+    expect(
+      getAppAuthorizationErrorMessage(
+        { app: { owner: { displayName: 'OwnerName' } } } as FullAppInfo,
+        'example-app',
+        'publish'
+      )
+    ).toContain('owner (OwnerName) or as a designated maintainer');
+  });
+});

--- a/packages/cli/src/util/authorization/appAuthorization.test.ts
+++ b/packages/cli/src/util/authorization/appAuthorization.test.ts
@@ -1,5 +1,3 @@
-// eslint-disable-next-line no-restricted-imports
-import type { FullAppInfo } from '@devvit/protos/types/devvit/dev_portal/app/app.js';
 import { describe, expect, test } from 'vitest';
 
 import {
@@ -9,34 +7,69 @@ import {
 } from './appAuthorization.js';
 
 describe('appAuthorization', () => {
-  test('allows the app owner to write app versions', () => {
+  test('recognizes the app owner by stable account ID', () => {
     const appInfo = {
       app: {
-        owner: { displayName: 'OwnerName' },
+        owner: { id: 't2_owner', displayName: 'OriginalOwnerName' },
       },
     };
 
-    const role = getAppAuthorizationRole(appInfo as FullAppInfo, 'ownername');
+    const role = getAppAuthorizationRole(appInfo, {
+      id: 't2_owner',
+      displayName: 'RenamedOwner',
+    });
 
     expect(role).toBe('owner');
     expect(canWriteAppVersion(role)).toBe(true);
   });
 
-  test('allows a designated app maintainer to write app versions', () => {
+  test('does not fall back to a matching display name when stable IDs disagree', () => {
     const appInfo = {
       app: {
-        owner: { displayName: 'OwnerName' },
-        maintainers: [{ displayName: 'MaintainerName' }],
+        owner: { id: 't2_owner', displayName: 'SharedName' },
       },
     };
 
-    const role = getAppAuthorizationRole(appInfo as FullAppInfo, 'maintainername');
+    expect(
+      getAppAuthorizationRole(appInfo, {
+        id: 't2_other',
+        displayName: 'SharedName',
+      })
+    ).toBe('unauthorized');
+  });
+
+  test('recognizes a maintainer from typed authorization metadata by account ID', () => {
+    const appInfo = {
+      app: {
+        owner: { id: 't2_owner', displayName: 'OwnerName' },
+        authorization: {
+          maintainers: [{ id: 't2_maintainer', displayName: 'MaintainerName' }],
+        },
+      },
+    };
+
+    const role = getAppAuthorizationRole(appInfo, {
+      id: 't2_maintainer',
+      displayName: 'RenamedMaintainer',
+    });
 
     expect(role).toBe('maintainer');
     expect(canWriteAppVersion(role)).toBe(true);
   });
 
-  test('does not allow unrelated developers to write app versions', () => {
+  test('accepts a backend-computed current-user role', () => {
+    const appInfo = {
+      app: {
+        authorization: {
+          currentUserRole: 'maintainer',
+        },
+      },
+    };
+
+    expect(getAppAuthorizationRole(appInfo, '')).toBe('maintainer');
+  });
+
+  test('temporarily supports the prototype maintainer list by display name', () => {
     const appInfo = {
       app: {
         owner: { displayName: 'OwnerName' },
@@ -44,16 +77,45 @@ describe('appAuthorization', () => {
       },
     };
 
-    const role = getAppAuthorizationRole(appInfo as FullAppInfo, 'OtherDeveloper');
+    expect(getAppAuthorizationRole(appInfo, ' maintainername ')).toBe('maintainer');
+  });
+
+  test('does not authorize an unrelated developer', () => {
+    const appInfo = {
+      app: {
+        owner: { id: 't2_owner', displayName: 'OwnerName' },
+        authorization: {
+          maintainers: [{ id: 't2_maintainer', displayName: 'MaintainerName' }],
+        },
+      },
+    };
+
+    const role = getAppAuthorizationRole(appInfo, {
+      id: 't2_other',
+      displayName: 'OtherDeveloper',
+    });
 
     expect(role).toBe('unauthorized');
     expect(canWriteAppVersion(role)).toBe(false);
   });
 
+  test.each(['owner', 'maintainer'] as const)(
+    'allows the %s role to upload, publish, and playtest app versions',
+    (role) => {
+      expect(canWriteAppVersion(role)).toBe(true);
+    }
+  );
+
+  test('denies app-version writes when authorization metadata is missing', () => {
+    expect(getAppAuthorizationRole(undefined, 'OwnerName')).toBe('unauthorized');
+    expect(getAppAuthorizationRole({ app: null }, 'OwnerName')).toBe('unauthorized');
+    expect(getAppAuthorizationRole({ app: {} }, '')).toBe('unauthorized');
+  });
+
   test('uses a maintainer-aware error message', () => {
     expect(
       getAppAuthorizationErrorMessage(
-        { app: { owner: { displayName: 'OwnerName' } } } as FullAppInfo,
+        { app: { owner: { displayName: 'OwnerName' } } },
         'example-app',
         'publish'
       )

--- a/packages/cli/src/util/authorization/appAuthorization.ts
+++ b/packages/cli/src/util/authorization/appAuthorization.ts
@@ -1,39 +1,126 @@
-// eslint-disable-next-line no-restricted-imports
-import type { FullAppInfo } from '@devvit/protos/types/devvit/dev_portal/app/app.js';
-
 export type AppAuthorizationRole = 'owner' | 'maintainer' | 'unauthorized';
-export type AppWriteAction = 'upload' | 'publish';
+export type AppWriteAction = 'upload' | 'publish' | 'playtest';
 
-type DeveloperDisplayName = {
+export type DeveloperIdentity = Readonly<{
+  id?: string;
   displayName?: string;
-};
+}>;
 
-type AppWithMaintainers = NonNullable<FullAppInfo['app']> & {
-  maintainers?: readonly DeveloperDisplayName[];
-};
+type AppAuthorizationData = Readonly<{
+  owner?: DeveloperIdentity;
+  maintainers: readonly DeveloperIdentity[];
+  currentUserRole?: AppAuthorizationRole;
+}>;
+
+type UnknownRecord = Record<string, unknown>;
+
+function asRecord(value: unknown): UnknownRecord | undefined {
+  return typeof value === 'object' && value !== null ? (value as UnknownRecord) : undefined;
+}
+
+function readString(value: unknown): string | undefined {
+  return typeof value === 'string' ? value : undefined;
+}
+
+function readIdentity(value: unknown): DeveloperIdentity | undefined {
+  const record = asRecord(value);
+  if (!record) return undefined;
+
+  const identity = {
+    id: readString(record.id),
+    displayName: readString(record.displayName),
+  } satisfies DeveloperIdentity;
+
+  return identity.id || identity.displayName ? identity : undefined;
+}
+
+function readIdentities(value: unknown): readonly DeveloperIdentity[] {
+  if (!Array.isArray(value)) return [];
+
+  return value
+    .map(readIdentity)
+    .filter((identity): identity is DeveloperIdentity => identity !== undefined);
+}
+
+function readAuthorizationRole(value: unknown): AppAuthorizationRole | undefined {
+  return value === 'owner' || value === 'maintainer' || value === 'unauthorized'
+    ? value
+    : undefined;
+}
+
+/**
+ * Compatibility boundary for authorization metadata returned by the app API.
+ *
+ * The generated FullAppInfo type does not yet expose maintainer authorization.
+ * This parser accepts unknown input and supports both a future
+ * app.authorization payload and the prototype app.maintainers field. Replace
+ * this parser with the generated type once the backend/protobuf contract lands.
+ */
+function readAppAuthorizationData(appInfo: unknown): AppAuthorizationData {
+  const app = asRecord(asRecord(appInfo)?.app);
+  if (!app) return { maintainers: [] };
+
+  const authorization = asRecord(app.authorization);
+  const typedMaintainers = readIdentities(authorization?.maintainers);
+
+  return {
+    owner: readIdentity(app.owner),
+    maintainers: typedMaintainers.length > 0 ? typedMaintainers : readIdentities(app.maintainers),
+    currentUserRole: readAuthorizationRole(
+      authorization?.currentUserRole ?? app.currentUserRole
+    ),
+  };
+}
+
+function normalizeId(id: string | undefined): string | undefined {
+  const normalized = id?.trim();
+  return normalized || undefined;
+}
 
 function normalizeDisplayName(displayName: string | undefined): string | undefined {
-  return displayName?.trim().toLowerCase();
+  const normalized = displayName?.trim().toLowerCase();
+  return normalized || undefined;
+}
+
+function isSameDeveloper(
+  candidate: DeveloperIdentity | undefined,
+  currentUser: DeveloperIdentity
+): boolean {
+  if (!candidate) return false;
+
+  const candidateId = normalizeId(candidate.id);
+  const currentUserId = normalizeId(currentUser.id);
+  if (candidateId && currentUserId) {
+    return candidateId === currentUserId;
+  }
+
+  const candidateDisplayName = normalizeDisplayName(candidate.displayName);
+  const currentUserDisplayName = normalizeDisplayName(currentUser.displayName);
+  return !!candidateDisplayName && candidateDisplayName === currentUserDisplayName;
 }
 
 export function getAppAuthorizationRole(
-  appInfo: FullAppInfo | undefined,
-  username: string
+  appInfo: unknown,
+  currentUser: string | DeveloperIdentity
 ): AppAuthorizationRole {
-  const app = appInfo?.app as AppWithMaintainers | undefined;
-  const normalizedUsername = normalizeDisplayName(username);
+  const authorization = readAppAuthorizationData(appInfo);
 
-  if (!app || !normalizedUsername) {
-    return 'unauthorized';
+  // Prefer a backend-computed role when available. The server must remain the
+  // authoritative enforcement boundary for all app-version write operations.
+  if (authorization.currentUserRole) {
+    return authorization.currentUserRole;
   }
 
-  if (normalizeDisplayName(app.owner?.displayName) === normalizedUsername) {
+  const currentUserIdentity: DeveloperIdentity =
+    typeof currentUser === 'string' ? { displayName: currentUser } : currentUser;
+
+  if (isSameDeveloper(authorization.owner, currentUserIdentity)) {
     return 'owner';
   }
 
   if (
-    app.maintainers?.some(
-      (maintainer) => normalizeDisplayName(maintainer.displayName) === normalizedUsername
+    authorization.maintainers.some((maintainer) =>
+      isSameDeveloper(maintainer, currentUserIdentity)
     )
   ) {
     return 'maintainer';
@@ -47,9 +134,11 @@ export function canWriteAppVersion(role: AppAuthorizationRole): boolean {
 }
 
 export function getAppAuthorizationErrorMessage(
-  appInfo: FullAppInfo,
+  appInfo: unknown,
   appName: string,
   action: AppWriteAction
 ): string {
-  return `You are not authorized to ${action} the app "${appName}". Please check that you are logged in as the owner (${appInfo.app?.owner?.displayName ?? '<unknown>'}) or as a designated maintainer.`;
+  const ownerDisplayName = readAppAuthorizationData(appInfo).owner?.displayName ?? '<unknown>';
+
+  return `You are not authorized to ${action} the app "${appName}". Please check that you are logged in as the owner (${ownerDisplayName}) or as a designated maintainer.`;
 }

--- a/packages/cli/src/util/authorization/appAuthorization.ts
+++ b/packages/cli/src/util/authorization/appAuthorization.ts
@@ -1,0 +1,55 @@
+// eslint-disable-next-line no-restricted-imports
+import type { FullAppInfo } from '@devvit/protos/types/devvit/dev_portal/app/app.js';
+
+export type AppAuthorizationRole = 'owner' | 'maintainer' | 'unauthorized';
+export type AppWriteAction = 'upload' | 'publish';
+
+type DeveloperDisplayName = {
+  displayName?: string;
+};
+
+type AppWithMaintainers = NonNullable<FullAppInfo['app']> & {
+  maintainers?: readonly DeveloperDisplayName[];
+};
+
+function normalizeDisplayName(displayName: string | undefined): string | undefined {
+  return displayName?.trim().toLowerCase();
+}
+
+export function getAppAuthorizationRole(
+  appInfo: FullAppInfo | undefined,
+  username: string
+): AppAuthorizationRole {
+  const app = appInfo?.app as AppWithMaintainers | undefined;
+  const normalizedUsername = normalizeDisplayName(username);
+
+  if (!app || !normalizedUsername) {
+    return 'unauthorized';
+  }
+
+  if (normalizeDisplayName(app.owner?.displayName) === normalizedUsername) {
+    return 'owner';
+  }
+
+  if (
+    app.maintainers?.some(
+      (maintainer) => normalizeDisplayName(maintainer.displayName) === normalizedUsername
+    )
+  ) {
+    return 'maintainer';
+  }
+
+  return 'unauthorized';
+}
+
+export function canWriteAppVersion(role: AppAuthorizationRole): boolean {
+  return role === 'owner' || role === 'maintainer';
+}
+
+export function getAppAuthorizationErrorMessage(
+  appInfo: FullAppInfo,
+  appName: string,
+  action: AppWriteAction
+): string {
+  return `You are not authorized to ${action} the app "${appName}". Please check that you are logged in as the owner (${appInfo.app?.owner?.displayName ?? '<unknown>'}) or as a designated maintainer.`;
+}


### PR DESCRIPTION
Related to #272

## 💸 TL;DR

This PR prototypes CLI-side support for an optional **maintainer** role on Devvit apps.

Devvit currently limits app uploads and publishing to the app owner. That model works for individual projects, but it creates a deployment bottleneck for mature, collaboratively maintained apps: reviewed backend improvements still cannot be released unless the sole owner is available.

For Bot Bouncer, multiple contributors help review code, develop features, handle appeals, and improve moderator workflows, but every backend deployment still depends on one app owner. When that owner is occupied with the appeal backlog or other operational work, improvements that could reduce moderator workload become harder to ship.

A limited maintainer role would follow the principle of least privilege. Trusted contributors could handle routine deployment work without receiving ownership, access to sensitive owner-only capabilities, or control over project governance.

> **This is a prototype, not an end-to-end implementation.** The checked-in API/protobuf definitions do not yet expose maintainers, and the backend must remain the authoritative enforcement boundary for every protected operation.

## 📜 Details

**Prototype behavior**

This PR adds shared CLI-side authorization logic that can classify the current developer as:

- `owner`
- `maintainer`
- `unauthorized`

It updates:

- `devvit upload`
- `devvit publish`
- `devvit playtest`

Those commands can recognize owners and designated maintainers when compatible authorization metadata is available. Existing Reddit employee override paths are preserved.

**Identity matching**

The prototype prefers stable Reddit account IDs over display names.

Display names are used only when stable IDs are unavailable. If both identities contain IDs, matching display names do not override differing IDs.

**Authorization metadata compatibility**

The shared helper can read authorization information from:

- A future backend-computed `currentUserRole`.
- A future typed authorization payload containing maintainers.
- The prototype `app.maintainers` field as a temporary compatibility fallback.

The parser accepts unknown API data rather than asserting that `FullAppInfo` already contains fields missing from the generated type.

**Command-specific behavior**

`devvit upload`:

- Passes the authenticated account ID and display name to the shared helper.
- Recognizes owners and maintainers.
- Preserves the employee override.
- Corrects the unauthorized override error so that it refers to uploading rather than playtesting.
- Updates the command description to mention designated maintainers.

`devvit publish`:

- Passes the authenticated account ID and display name to the shared helper.
- Recognizes owners and maintainers.
- Preserves the employee override.
- Uses a maintainer-aware authorization error message.

`devvit playtest`:

- Uses the same owner-or-maintainer authorization decision as upload and publish.
- Preserves the employee override.
- Returns a clearer error for users who are neither the owner nor a designated maintainer.

**Production authorization model**

The preferred production design is for the backend to return either:

- A typed current-user authorization role, or
- Action-specific capabilities such as `upload`, `publish`, `playtest`, and `rollback`.

The CLI may use those values for early feedback and clearer errors, but the server must independently enforce every protected operation.

The temporary runtime parser should be replaced with generated protobuf/API types after the backend contract is implemented.

**Remaining implementation work**

- Add a backend/protobuf representation for maintainers or backend-computed capabilities.
- Enforce maintainer permissions server-side.
- Add owner-managed maintainer assignment and removal.
- Add rollback authorization.
- Replace the compatibility parser with generated API types.
- Add command-level upload, publish, playtest, unauthorized-user, and employee-override tests.
- Run the relevant workspace tests and lint checks.
- Complete a successful CI run.

## 🧪 Testing Steps / Validation

Expanded unit coverage includes:

- Owner recognition by stable account ID.
- Maintainer recognition by stable account ID.
- Rejection when account IDs differ despite matching display names.
- Backend-computed maintainer authorization.
- Temporary compatibility with the prototype maintainer list.
- Unauthorized-user rejection.
- Missing or incomplete authorization metadata.
- Owner and maintainer app-version write eligibility.
- Maintainer-aware error messages.

Validation completed:

- `git diff --check`
- Guarded source transformations verified against the expected source blocks.

Full workspace tests have not yet completed successfully. A prior dependency installation attempt failed because `packages/apps/devvit-dev-bot/package.json` references `devvit@0.13.6-dev`, which was unavailable from the public npm registry.

GitHub Actions has not yet produced a workflow run for the current PR head.

## ✅ Checks

<!-- Make sure your pr passes the CI checks and do check the following fields as needed - -->
- [ ] CI tests (if present) are passing
- [x] Adheres to code style for repo
- [x] Contributor License Agreement (CLA) completed if not a Reddit employee