### PR TITLE
Bound concurrent filesystem reads

### DIFF
--- a/packages/cli/src/util/AssetUploader.ts
+++ b/packages/cli/src/util/AssetUploader.ts
@@ -39,6 +39,7 @@ import { dirExists } from './files.js';
 import { retryAsync } from './retryAsync.js';
 
 const DEFAULT_PARALLEL_UPLOADS = 7;
+const MAX_PARALLEL_ASSET_READS = 16;
 
 let PARALLEL_UPLOADS = parseInt(process.env['DEVVIT_PARALLEL_UPLOADS'] || '0');
 if (isNaN(PARALLEL_UPLOADS) || PARALLEL_UPLOADS < 1) {
@@ -608,8 +609,9 @@ export async function queryAssets(
   const assets = (await tinyglob(assetsGlob, { filesOnly: true, absolute: true })).filter(
     (asset) => allowedExtensions.length === 0 || allowedExtensions.includes(path.extname(asset))
   );
-  return await Promise.all(
-    assets.map(async (asset) => {
+  return await mapAsyncWithMaxConcurrency(
+    assets,
+    async (asset) => {
       const filename = path.relative(dir, asset).replaceAll(path.sep, '/');
       let file = await fsp.readFile(asset);
 
@@ -630,7 +632,8 @@ export async function queryAssets(
         isWebviewAsset: assetKind === 'Client',
         contents,
       };
-    })
+    },
+    MAX_PARALLEL_ASSET_READS
   );
 }
 

--- a/packages/cli/src/util/getAppSourceZip.ts
+++ b/packages/cli/src/util/getAppSourceZip.ts
@@ -1,12 +1,14 @@
 import fsp from 'node:fs/promises';
 import path from 'node:path';
 
+import { mapAsyncWithMaxConcurrency } from '@devvit/shared-types/mapAsyncWithMaxConcurrency.js';
 import ignore from 'ignore';
 import JSZip from 'jszip';
 
 import { DevvitCommand } from './commands/DevvitCommand.js';
 
 const ALWAYS_IGNORED_PATHS = Object.freeze(['node_modules', '.env', '.git']);
+const MAX_PARALLEL_SOURCE_READS = 16;
 
 export async function getAppSourceZip(cmd: DevvitCommand): Promise<ArrayBuffer> {
   const zip = new JSZip();
@@ -51,7 +53,7 @@ async function addDirectoryToZip(
   const entries = await fsp.readdir(dir, { withFileTypes: true });
 
   // Process entries in parallel
-  const filePromises: Promise<void>[] = [];
+  const fileCallbacks: (() => Promise<void>)[] = [];
   const dirCallbacks: (() => Promise<void>)[] = [];
 
   for (const entry of entries) {
@@ -71,18 +73,20 @@ async function addDirectoryToZip(
         );
       }
     } else if (entry.isFile()) {
-      // Read files & add them in parallel though
-      filePromises.push(
-        (async () => {
-          const content = await fsp.readFile(fullPath);
-          zipFolder.file(entry.name, content);
-        })()
-      );
+      // Defer file reads so concurrency can be bounded below.
+      fileCallbacks.push(async () => {
+        const content = await fsp.readFile(fullPath);
+        zipFolder.file(entry.name, content);
+      });
     }
   }
 
-  // Wait for all file reads to complete
-  await Promise.all(filePromises);
+  // Read files concurrently without opening every file at once.
+  await mapAsyncWithMaxConcurrency(
+    fileCallbacks,
+    (readFile) => readFile(),
+    MAX_PARALLEL_SOURCE_READS
+  );
 
   // Then, process the directories in serial
   for (const dirCallback of dirCallbacks) {


### PR DESCRIPTION
Closes #278

## 💸 TL;DR

Bounds concurrent filesystem reads during CLI asset collection and source ZIP generation.

Large projects previously started a filesystem read for every discovered file at once. This change limits those reads to 16 concurrent operations, reducing the risk of excessive memory usage or file-descriptor exhaustion.

## 📜 Details

This PR applies the existing `mapAsyncWithMaxConcurrency()` utility to two CLI filesystem operations:

* `queryAssets()` now limits concurrent asset reads to 16.
* `getAppSourceZip()` now defers source-file reads and processes them with a concurrency limit of 16.

Directory traversal behavior remains unchanged. The source ZIP function continues to process directories serially after completing the bounded file reads for the current directory.

No public API behavior is changed.

Design Doc: N/A

Jira: N/A

## 🧪 Testing Steps / Validation

* Ran `git diff --check` successfully.
* Reviewed the complete staged diff for both modified files.
* Confirmed the unbounded asset-read `Promise.all()` was replaced with `mapAsyncWithMaxConcurrency()`.
* Confirmed source-file reads are deferred rather than started while directory entries are collected.
* Confirmed the source ZIP operation no longer calls `Promise.all(filePromises)`.

A complete local dependency installation and test run could not be performed because the public repository references unpublished internal packages, including `devvit@0.13.9-dev` and `@reddit/faceplate-ui`.

## ✅ Checks

* [ ] CI tests (if present) are passing
* [x] Adheres to code style for repo
* [x] Contributor License Agreement (CLA) completed if not a Reddit employee
